### PR TITLE
一覧画面

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,6 +51,8 @@ dependencies {
     })
     implementation "com.android.support:appcompat-v7:${support_lib_version}"
     implementation "com.android.support:design:${support_lib_version}"
+    implementation "com.android.support:recyclerview-v7:${support_lib_version}"
+    implementation "com.android.support:cardview-v7:${support_lib_version}"
     implementation 'com.android.support.constraint:constraint-layout:1.0.2'
     implementation "android.arch.persistence.room:runtime:${arch_lib_version}"
     annotationProcessor "android.arch.persistence.room:compiler:${arch_lib_version}"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     implementation "com.android.support:design:${support_lib_version}"
     implementation "com.android.support:recyclerview-v7:${support_lib_version}"
     implementation "com.android.support:cardview-v7:${support_lib_version}"
-    implementation 'com.android.support.constraint:constraint-layout:1.0.2'
+    implementation 'com.android.support.constraint:constraint-layout:1.1.0-beta1'
     implementation "android.arch.persistence.room:runtime:${arch_lib_version}"
     annotationProcessor "android.arch.persistence.room:compiler:${arch_lib_version}"
 

--- a/app/src/debug/assets/test_data.json
+++ b/app/src/debug/assets/test_data.json
@@ -11,6 +11,6 @@
   {"id":9,"question":"charge","answer":"請求する","level":3,"count":0},
   {"id":10,"question":"check","answer":"確認する","level":4,"count":0},
   {"id":11,"question":"colleague","answer":"同僚","level":4,"count":0},
-  {"id":12,"question":"committee","answer":"役員会","level":5,"count":0},
-  {"id":13,"question":"condition","answer":"状態","level":5,"count":0}
+  {"id":12,"question":"committee","answer":"役員会","level":4,"count":1},
+  {"id":13,"question":"condition","answer":"状態","level":4,"count":2}
 ]

--- a/app/src/main/java/com/github/mag0716/memorytraining/activity/ListActivity.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/activity/ListActivity.java
@@ -17,6 +17,7 @@ import com.github.mag0716.memorytraining.model.Memory;
 import com.github.mag0716.memorytraining.repository.database.MemoryDao;
 import com.github.mag0716.memorytraining.view.adapter.MemoryListAdapter;
 import com.github.mag0716.memorytraining.view.decoration.CardItemDecoration;
+import com.github.mag0716.memorytraining.viewmodel.ListViewModel;
 
 import java.util.List;
 
@@ -31,6 +32,7 @@ import io.reactivex.schedulers.Schedulers;
 public class ListActivity extends AppCompatActivity {
 
     private ActivityListBinding binding;
+    private ListViewModel viewModel = new ListViewModel();
 
     private MemoryListAdapter adapter;
     private RecyclerView.ItemDecoration itemDecoration;
@@ -64,7 +66,10 @@ public class ListActivity extends AppCompatActivity {
         Single.create((SingleOnSubscribe<List<Memory>>) emitter -> emitter.onSuccess(memoryDao.loadAll()))
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(memoryList -> adapter.addAll(memoryList));
+                .subscribe(memoryList -> {
+                    viewModel.addAll(memoryList);
+                    adapter.addAll(viewModel.getItemViewModelList());
+                });
     }
 
     @Override

--- a/app/src/main/java/com/github/mag0716/memorytraining/activity/ListActivity.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/activity/ListActivity.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import android.support.design.widget.Snackbar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -15,6 +16,7 @@ import com.github.mag0716.memorytraining.databinding.ActivityListBinding;
 import com.github.mag0716.memorytraining.model.Memory;
 import com.github.mag0716.memorytraining.repository.database.MemoryDao;
 import com.github.mag0716.memorytraining.view.adapter.MemoryListAdapter;
+import com.github.mag0716.memorytraining.view.decoration.CardItemDecoration;
 
 import java.util.List;
 
@@ -31,6 +33,7 @@ public class ListActivity extends AppCompatActivity {
     private ActivityListBinding binding;
 
     private MemoryListAdapter adapter;
+    private RecyclerView.ItemDecoration itemDecoration;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -48,6 +51,8 @@ public class ListActivity extends AppCompatActivity {
 
         adapter = new MemoryListAdapter(this);
         binding.content.trainingList.setLayoutManager(new LinearLayoutManager(this));
+        itemDecoration = new CardItemDecoration(this);
+        binding.content.trainingList.addItemDecoration(itemDecoration);
         binding.content.trainingList.setAdapter(adapter);
     }
 
@@ -60,6 +65,12 @@ public class ListActivity extends AppCompatActivity {
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(memoryList -> adapter.addAll(memoryList));
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        binding.content.trainingList.removeItemDecoration(itemDecoration);
     }
 
     @Override

--- a/app/src/main/java/com/github/mag0716/memorytraining/activity/ListActivity.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/activity/ListActivity.java
@@ -14,6 +14,7 @@ import com.github.mag0716.memorytraining.Application;
 import com.github.mag0716.memorytraining.R;
 import com.github.mag0716.memorytraining.databinding.ActivityListBinding;
 import com.github.mag0716.memorytraining.model.Memory;
+import com.github.mag0716.memorytraining.presenter.ListPresenter;
 import com.github.mag0716.memorytraining.repository.database.MemoryDao;
 import com.github.mag0716.memorytraining.view.adapter.MemoryListAdapter;
 import com.github.mag0716.memorytraining.view.decoration.CardItemDecoration;
@@ -33,6 +34,7 @@ public class ListActivity extends AppCompatActivity {
 
     private ActivityListBinding binding;
     private ListViewModel viewModel = new ListViewModel();
+    private ListPresenter presenter;
 
     private MemoryListAdapter adapter;
     private RecyclerView.ItemDecoration itemDecoration;
@@ -43,6 +45,8 @@ public class ListActivity extends AppCompatActivity {
         binding = DataBindingUtil.setContentView(this, R.layout.activity_list);
         setSupportActionBar(binding.toolbar);
 
+        presenter = new ListPresenter(((Application) getApplication()).getDatabase().memoryDao());
+
         binding.fab.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -51,7 +55,7 @@ public class ListActivity extends AppCompatActivity {
             }
         });
 
-        adapter = new MemoryListAdapter(this);
+        adapter = new MemoryListAdapter(this, presenter);
         binding.content.trainingList.setLayoutManager(new LinearLayoutManager(this));
         itemDecoration = new CardItemDecoration(this);
         binding.content.trainingList.addItemDecoration(itemDecoration);
@@ -62,6 +66,7 @@ public class ListActivity extends AppCompatActivity {
     protected void onResume() {
         super.onResume();
 
+        // TODO: Presenter に委譲
         final MemoryDao memoryDao = ((Application) getApplication()).getDatabase().memoryDao();
         Single.create((SingleOnSubscribe<List<Memory>>) emitter -> emitter.onSuccess(memoryDao.loadAll()))
                 .subscribeOn(Schedulers.io())

--- a/app/src/main/java/com/github/mag0716/memorytraining/activity/ListActivity.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/activity/ListActivity.java
@@ -2,13 +2,11 @@ package com.github.mag0716.memorytraining.activity;
 
 import android.databinding.DataBindingUtil;
 import android.os.Bundle;
-import android.support.design.widget.Snackbar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.Menu;
 import android.view.MenuItem;
-import android.view.View;
 
 import com.github.mag0716.memorytraining.Application;
 import com.github.mag0716.memorytraining.R;
@@ -46,15 +44,7 @@ public class ListActivity extends AppCompatActivity {
         setSupportActionBar(binding.toolbar);
 
         presenter = new ListPresenter(((Application) getApplication()).getDatabase().memoryDao());
-
-        binding.fab.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                Snackbar.make(view, "Replace with your own action", Snackbar.LENGTH_LONG)
-                        .setAction("Action", null).show();
-            }
-        });
-
+        binding.setPresenter(presenter);
         adapter = new MemoryListAdapter(this, presenter);
         binding.content.trainingList.setLayoutManager(new LinearLayoutManager(this));
         itemDecoration = new CardItemDecoration(this);

--- a/app/src/main/java/com/github/mag0716/memorytraining/activity/ListActivity.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/activity/ListActivity.java
@@ -1,33 +1,65 @@
 package com.github.mag0716.memorytraining.activity;
 
+import android.databinding.DataBindingUtil;
 import android.os.Bundle;
-import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.Snackbar;
 import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
+import android.support.v7.widget.LinearLayoutManager;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 
+import com.github.mag0716.memorytraining.Application;
 import com.github.mag0716.memorytraining.R;
+import com.github.mag0716.memorytraining.databinding.ActivityListBinding;
+import com.github.mag0716.memorytraining.model.Memory;
+import com.github.mag0716.memorytraining.repository.database.MemoryDao;
+import com.github.mag0716.memorytraining.view.adapter.MemoryListAdapter;
 
+import java.util.List;
+
+import io.reactivex.Single;
+import io.reactivex.SingleOnSubscribe;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.schedulers.Schedulers;
+
+/**
+ * 訓練対象データ一覧画面
+ */
 public class ListActivity extends AppCompatActivity {
+
+    private ActivityListBinding binding;
+
+    private MemoryListAdapter adapter;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_list);
-        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
-        setSupportActionBar(toolbar);
+        binding = DataBindingUtil.setContentView(this, R.layout.activity_list);
+        setSupportActionBar(binding.toolbar);
 
-        FloatingActionButton fab = (FloatingActionButton) findViewById(R.id.fab);
-        fab.setOnClickListener(new View.OnClickListener() {
+        binding.fab.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
                 Snackbar.make(view, "Replace with your own action", Snackbar.LENGTH_LONG)
                         .setAction("Action", null).show();
             }
         });
+
+        adapter = new MemoryListAdapter(this);
+        binding.content.trainingList.setLayoutManager(new LinearLayoutManager(this));
+        binding.content.trainingList.setAdapter(adapter);
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+
+        final MemoryDao memoryDao = ((Application) getApplication()).getDatabase().memoryDao();
+        Single.create((SingleOnSubscribe<List<Memory>>) emitter -> emitter.onSuccess(memoryDao.loadAll()))
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(memoryList -> adapter.addAll(memoryList));
     }
 
     @Override

--- a/app/src/main/java/com/github/mag0716/memorytraining/activity/ListActivity.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/activity/ListActivity.java
@@ -38,6 +38,7 @@ public class ListActivity extends AppCompatActivity implements ListView {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         binding = DataBindingUtil.setContentView(this, R.layout.activity_list);
+        binding.content.setViewModel(viewModel);
         setSupportActionBar(binding.toolbar);
 
         presenter = new ListPresenter(((Application) getApplication()).getDatabase().memoryDao());
@@ -99,12 +100,14 @@ public class ListActivity extends AppCompatActivity implements ListView {
 
     @Override
     public void showMemoryList(@NonNull List<Memory> memoryList) {
+        // TODO: ViewModel と Adapter に対して同じ処理を行っているので、ViewModel のみの変更で、View も変更されるようにバインディングする
         viewModel.addAll(memoryList);
         adapter.addAll(viewModel.getItemViewModelList());
     }
 
     @Override
     public void dismissMemory(long id) {
+        viewModel.remove(id);
         adapter.remove(id);
     }
 

--- a/app/src/main/java/com/github/mag0716/memorytraining/model/Level.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/model/Level.java
@@ -16,81 +16,81 @@ public enum Level {
 
     LEVEL1(0) {
         @Override
-        long getTrainingInterval() {
+        public long getTrainingInterval() {
             return TimeUnit.SECONDS.toMillis(30);
         }
 
         @Override
-        Level getPreviousLevel(int trainingCount) {
+        public Level getPreviousLevel(int trainingCount) {
             return LEVEL1;
         }
 
         @Override
-        Level getNextLevel(int trainingCount) {
+        public Level getNextLevel(int trainingCount) {
             return LEVEL2;
         }
     },
     LEVEL2(1) {
         @Override
-        long getTrainingInterval() {
+        public long getTrainingInterval() {
             return TimeUnit.MINUTES.toMillis(3);
         }
 
         @Override
-        Level getPreviousLevel(int trainingCount) {
+        public Level getPreviousLevel(int trainingCount) {
             return LEVEL1;
         }
 
         @Override
-        Level getNextLevel(int trainingCount) {
+        public Level getNextLevel(int trainingCount) {
             return LEVEL3;
         }
     },
     LEVEL3(2) {
         @Override
-        long getTrainingInterval() {
+        public long getTrainingInterval() {
             return TimeUnit.HOURS.toMillis(1);
         }
 
         @Override
-        Level getPreviousLevel(int trainingCount) {
+        public Level getPreviousLevel(int trainingCount) {
             return LEVEL2;
         }
 
         @Override
-        Level getNextLevel(int trainingCount) {
+        public Level getNextLevel(int trainingCount) {
             return LEVEL4;
         }
     },
     LEVEL4(3) {
         @Override
-        long getTrainingInterval() {
+        public long getTrainingInterval() {
             return TimeUnit.DAYS.toMillis(1);
         }
 
         @Override
-        Level getPreviousLevel(int trainingCount) {
+        public Level getPreviousLevel(int trainingCount) {
             return LEVEL3;
         }
 
         @Override
-        Level getNextLevel(int trainingCount) {
+        public Level getNextLevel(int trainingCount) {
             return LEVEL5;
         }
     },
     LEVEL5(4) {
         @Override
-        long getTrainingInterval() {
+        public long getTrainingInterval() {
             return TimeUnit.DAYS.toMillis(30);
         }
 
         @Override
-        Level getPreviousLevel(int trainingCount) {
+        public Level getPreviousLevel(int trainingCount) {
             return LEVEL4;
         }
 
         @Override
-        Level getNextLevel(int trainingCount) {
+        public Level getNextLevel(int trainingCount) {
             return LEVEL5;
         }
     };
@@ -110,7 +110,7 @@ public enum Level {
      *
      * @return 訓練間隔[msec]
      */
-    abstract long getTrainingInterval();
+    public abstract long getTrainingInterval();
 
     /**
      * 前のレベルを取得する
@@ -118,7 +118,7 @@ public enum Level {
      * @param trainingCount 現在のレベルでの訓練回数
      * @return 前のレベル
      */
-    abstract Level getPreviousLevel(@IntRange(from = 0) int trainingCount);
+    public abstract Level getPreviousLevel(@IntRange(from = 0) int trainingCount);
 
     /**
      * 次のレベルを取得する
@@ -126,6 +126,6 @@ public enum Level {
      * @param trainingCount 現在のレベルでの訓練回数
      * @return 次のレベル
      */
-    abstract Level getNextLevel(@IntRange(from = 0) int trainingCount);
+    public abstract Level getNextLevel(@IntRange(from = 0) int trainingCount);
 
 }

--- a/app/src/main/java/com/github/mag0716/memorytraining/model/Level.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/model/Level.java
@@ -1,0 +1,131 @@
+package com.github.mag0716.memorytraining.model;
+
+import android.support.annotation.IntRange;
+
+import java.util.concurrent.TimeUnit;
+
+import lombok.Getter;
+
+/**
+ * 訓練レベル
+ * // TODO: 訓練回数による level down, up 処理修正 & 訓練間隔をランダムにする
+ * <p>
+ * Created by mag0716 on 2017/06/20.
+ */
+public enum Level {
+
+    LEVEL1(0) {
+        @Override
+        long getTrainingInterval() {
+            return TimeUnit.SECONDS.toMillis(30);
+        }
+
+        @Override
+        Level getPreviousLevel(int trainingCount) {
+            return LEVEL1;
+        }
+
+        @Override
+        Level getNextLevel(int trainingCount) {
+            return LEVEL2;
+        }
+    },
+    LEVEL2(1) {
+        @Override
+        long getTrainingInterval() {
+            return TimeUnit.MINUTES.toMillis(3);
+        }
+
+        @Override
+        Level getPreviousLevel(int trainingCount) {
+            return LEVEL1;
+        }
+
+        @Override
+        Level getNextLevel(int trainingCount) {
+            return LEVEL3;
+        }
+    },
+    LEVEL3(2) {
+        @Override
+        long getTrainingInterval() {
+            return TimeUnit.HOURS.toMillis(1);
+        }
+
+        @Override
+        Level getPreviousLevel(int trainingCount) {
+            return LEVEL2;
+        }
+
+        @Override
+        Level getNextLevel(int trainingCount) {
+            return LEVEL4;
+        }
+    },
+    LEVEL4(3) {
+        @Override
+        long getTrainingInterval() {
+            return TimeUnit.DAYS.toMillis(1);
+        }
+
+        @Override
+        Level getPreviousLevel(int trainingCount) {
+            return LEVEL3;
+        }
+
+        @Override
+        Level getNextLevel(int trainingCount) {
+            return LEVEL5;
+        }
+    },
+    LEVEL5(4) {
+        @Override
+        long getTrainingInterval() {
+            return TimeUnit.DAYS.toMillis(30);
+        }
+
+        @Override
+        Level getPreviousLevel(int trainingCount) {
+            return LEVEL4;
+        }
+
+        @Override
+        Level getNextLevel(int trainingCount) {
+            return LEVEL5;
+        }
+    };
+
+    /**
+     * ID
+     */
+    @Getter
+    private final int id;
+
+    Level(int id) {
+        this.id = id;
+    }
+
+    /**
+     * 訓練間隔取得
+     *
+     * @return 訓練間隔[msec]
+     */
+    abstract long getTrainingInterval();
+
+    /**
+     * 前のレベルを取得する
+     *
+     * @param trainingCount 現在のレベルでの訓練回数
+     * @return 前のレベル
+     */
+    abstract Level getPreviousLevel(@IntRange(from = 0) int trainingCount);
+
+    /**
+     * 次のレベルを取得する
+     *
+     * @param trainingCount 現在のレベルでの訓練回数
+     * @return 次のレベル
+     */
+    abstract Level getNextLevel(@IntRange(from = 0) int trainingCount);
+
+}

--- a/app/src/main/java/com/github/mag0716/memorytraining/model/Memory.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/model/Memory.java
@@ -2,11 +2,14 @@ package com.github.mag0716.memorytraining.model;
 
 import android.arch.persistence.room.ColumnInfo;
 import android.arch.persistence.room.Entity;
+import android.arch.persistence.room.Ignore;
 import android.arch.persistence.room.Index;
 import android.arch.persistence.room.PrimaryKey;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.provider.BaseColumns;
+import android.support.annotation.IntRange;
+import android.support.annotation.VisibleForTesting;
 
 /**
  * 訓練対象データ
@@ -42,6 +45,16 @@ public class Memory implements Parcelable {
      * 訓練回数
      */
     private int count;
+
+    @Ignore
+    @VisibleForTesting
+    Memory(long id, String question, String answer, int level, int count) {
+        this.id = id;
+        this.question = question;
+        this.answer = answer;
+        this.level = level;
+        this.count = count;
+    }
 
     /**
      * 次回訓練予定日時
@@ -95,6 +108,20 @@ public class Memory implements Parcelable {
 
     public void setNextTrainingDatetime(long nextTrainingDatetime) {
         this.nextTrainingDatetime = nextTrainingDatetime;
+    }
+
+    public void levelUp(@IntRange(from = 0, to = 4) int nextLevel) {
+        if (this.level == nextLevel) {
+            count++;
+        } else {
+            count = 0;
+        }
+        this.level = nextLevel;
+    }
+
+    public void levelDown(@IntRange(from = 0, to = 4) int nextLevel) {
+        count = 0;
+        this.level = nextLevel;
     }
 
     // region Parcelable

--- a/app/src/main/java/com/github/mag0716/memorytraining/presenter/ListPresenter.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/presenter/ListPresenter.java
@@ -78,10 +78,10 @@ public class ListPresenter implements IPresenter {
         Timber.d("levelUp : %d", id);
         disposables.add(loadMemory(id)
                 .map(memory -> {
-                    // TODO: level, count の更新
                     final Level currentLevel = Level.values()[memory.getLevel()];
                     final Level nextLevel = currentLevel.getNextLevel(memory.getCount());
                     memory.setNextTrainingDatetime(System.currentTimeMillis() + nextLevel.getTrainingInterval());
+                    memory.levelUp(nextLevel.getId());
                     dao.update(memory);
                     return memory;
                 })
@@ -103,10 +103,10 @@ public class ListPresenter implements IPresenter {
         Timber.d("levelDown : %d", id);
         disposables.add(loadMemory(id)
                 .map(memory -> {
-                    // TODO: level, count の更新
                     final Level currentLevel = Level.values()[memory.getLevel()];
                     final Level previousLevel = currentLevel.getPreviousLevel(memory.getCount());
                     memory.setNextTrainingDatetime(System.currentTimeMillis() + previousLevel.getTrainingInterval());
+                    memory.levelDown(previousLevel.getId());
                     dao.update(memory);
                     return memory;
                 })

--- a/app/src/main/java/com/github/mag0716/memorytraining/presenter/ListPresenter.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/presenter/ListPresenter.java
@@ -34,6 +34,14 @@ public class ListPresenter implements IPresenter {
     }
 
     /**
+     * 訓練データの追加
+     */
+    public void addMemory() {
+        Timber.d("addMemory");
+        // TODO: 追加画面へ遷移
+    }
+
+    /**
      * 記憶できていたのでレベルアップ
      *
      * @param id 訓練対象データ ID

--- a/app/src/main/java/com/github/mag0716/memorytraining/presenter/ListPresenter.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/presenter/ListPresenter.java
@@ -1,0 +1,55 @@
+package com.github.mag0716.memorytraining.presenter;
+
+import android.support.annotation.NonNull;
+
+import com.github.mag0716.memorytraining.repository.database.MemoryDao;
+import com.github.mag0716.memorytraining.view.IView;
+import com.github.mag0716.memorytraining.view.ListView;
+
+import lombok.RequiredArgsConstructor;
+import timber.log.Timber;
+
+/**
+ * 一覧画面の Presenter
+ * <p>
+ * Created by mag0716 on 2017/06/19.
+ */
+@RequiredArgsConstructor
+public class ListPresenter implements IPresenter {
+
+    private final MemoryDao dao;
+    private ListView view;
+
+    @Override
+    public void attachView(@NonNull IView view) {
+        if (!(view instanceof ListView)) {
+            throw new IllegalArgumentException("argument must need ListView.");
+        }
+        this.view = (ListView) view;
+    }
+
+    @Override
+    public void detachView() {
+        view = null;
+    }
+
+    /**
+     * 記憶できていたのでレベルアップ
+     *
+     * @param id 訓練対象データ ID
+     */
+    public void levelUp(long id) {
+        Timber.d("levelUp : %d", id);
+        // TODO: DB 更新 -> View 更新
+    }
+
+    /**
+     * 記憶できていなかったのでレベルダウン
+     *
+     * @param id 訓練対象データ ID
+     */
+    public void levelDown(long id) {
+        Timber.d("levelDown : %d", id);
+        // TODO: DB 更新 -> View 更新
+    }
+}

--- a/app/src/main/java/com/github/mag0716/memorytraining/presenter/ListPresenter.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/presenter/ListPresenter.java
@@ -2,10 +2,14 @@ package com.github.mag0716.memorytraining.presenter;
 
 import android.support.annotation.NonNull;
 
+import com.github.mag0716.memorytraining.model.Memory;
 import com.github.mag0716.memorytraining.repository.database.MemoryDao;
 import com.github.mag0716.memorytraining.view.IView;
 import com.github.mag0716.memorytraining.view.ListView;
 
+import io.reactivex.Single;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.schedulers.Schedulers;
 import lombok.RequiredArgsConstructor;
 import timber.log.Timber;
 
@@ -48,7 +52,18 @@ public class ListPresenter implements IPresenter {
      */
     public void levelUp(long id) {
         Timber.d("levelUp : %d", id);
-        // TODO: DB 更新 -> View 更新
+        loadMemory(id)
+                .map(memory -> {
+                    // TODO: DB 更新
+                    return memory;
+                })
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(memory -> {
+                            //TODO: View 更新
+                        },
+                        throwable -> Timber.w(throwable, "failed levelUp.")
+                );
     }
 
     /**
@@ -58,6 +73,29 @@ public class ListPresenter implements IPresenter {
      */
     public void levelDown(long id) {
         Timber.d("levelDown : %d", id);
-        // TODO: DB 更新 -> View 更新
+        loadMemory(id)
+                .map(memory -> {
+                    // TODO: DB 更新
+                    return memory;
+                })
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(memory -> {
+                            //TODO: View 更新
+                        },
+                        throwable -> Timber.w(throwable, "failed levelDown.")
+                );
+    }
+
+    private Single<Memory> loadMemory(long id) {
+        return Single.create(emitter -> {
+            final Memory memory = dao.load(id);
+            Timber.d("load : %s", memory);
+            if (memory != null) {
+                emitter.onSuccess(memory);
+            } else {
+                emitter.onError(new IllegalArgumentException("cannot load by id = " + id));
+            }
+        });
     }
 }

--- a/app/src/main/java/com/github/mag0716/memorytraining/repository/database/MemoryDao.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/repository/database/MemoryDao.java
@@ -7,6 +7,7 @@ import android.arch.persistence.room.OnConflictStrategy;
 import android.arch.persistence.room.Query;
 import android.arch.persistence.room.Update;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.github.mag0716.memorytraining.model.Memory;
 
@@ -27,6 +28,16 @@ public interface MemoryDao {
      */
     @Query("SELECT * from Memory")
     List<Memory> loadAll();
+
+    /**
+     * 指定した ID の Memory を取得
+     *
+     * @param id ID
+     * @return ID に合致する Memory
+     */
+    @Nullable
+    @Query("SELECT * from Memory WHERE _id = :id")
+    Memory load(long id);
 
     /**
      * 追加

--- a/app/src/main/java/com/github/mag0716/memorytraining/repository/database/MemoryDao.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/repository/database/MemoryDao.java
@@ -30,6 +30,15 @@ public interface MemoryDao {
     List<Memory> loadAll();
 
     /**
+     * 訓練日時が過ぎている Memory を取得
+     *
+     * @param trainingDatetime 訓練日時
+     * @return List<Memory>
+     */
+    @Query("SELECT * from Memory WHERE next_training_datetime <= :trainingDatetime")
+    List<Memory> loadAll(long trainingDatetime);
+
+    /**
      * 指定した ID の Memory を取得
      *
      * @param id ID
@@ -61,7 +70,7 @@ public interface MemoryDao {
      * @param memory 更新対象の Memory
      */
     @Update
-    void update(@NonNull Memory memory);
+    int update(@NonNull Memory memory);
 
     /**
      * 削除

--- a/app/src/main/java/com/github/mag0716/memorytraining/util/BindingUtil.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/util/BindingUtil.java
@@ -1,7 +1,10 @@
 package com.github.mag0716.memorytraining.util;
 
 import android.databinding.BindingAdapter;
+import android.support.annotation.DrawableRes;
+import android.support.annotation.NonNull;
 import android.view.View;
+import android.widget.ImageView;
 
 /**
  * Created by mag0716 on 2017/06/17.
@@ -9,12 +12,17 @@ import android.view.View;
 public class BindingUtil {
 
     @BindingAdapter("visibleOrInvisible")
-    public static void setVisibleOrInvisible(View view, boolean visible) {
+    public static void setVisibleOrInvisible(@NonNull View view, boolean visible) {
         view.setVisibility(visible ? View.VISIBLE : View.INVISIBLE);
     }
 
     @BindingAdapter("visibleOrGone")
-    public static void setVisibleOrGone(View view, boolean visible) {
+    public static void setVisibleOrGone(@NonNull View view, boolean visible) {
         view.setVisibility(visible ? View.VISIBLE : View.GONE);
+    }
+
+    @BindingAdapter("srcCompat")
+    public static void setSrcCompat(@NonNull ImageView view, @DrawableRes int resourceId) {
+        view.setImageResource(resourceId);
     }
 }

--- a/app/src/main/java/com/github/mag0716/memorytraining/util/BindingUtil.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/util/BindingUtil.java
@@ -1,0 +1,20 @@
+package com.github.mag0716.memorytraining.util;
+
+import android.databinding.BindingAdapter;
+import android.view.View;
+
+/**
+ * Created by mag0716 on 2017/06/17.
+ */
+public class BindingUtil {
+
+    @BindingAdapter("visibleOrInvisible")
+    public static void setVisibleOrInvisible(View view, boolean visible) {
+        view.setVisibility(visible ? View.VISIBLE : View.INVISIBLE);
+    }
+
+    @BindingAdapter("visibleOrGone")
+    public static void setVisibleOrGone(View view, boolean visible) {
+        view.setVisibility(visible ? View.VISIBLE : View.GONE);
+    }
+}

--- a/app/src/main/java/com/github/mag0716/memorytraining/view/IView.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/view/IView.java
@@ -17,5 +17,5 @@ public interface IView {
      * @return Context
      */
     @NonNull
-    public Context getContext();
+    Context getContext();
 }

--- a/app/src/main/java/com/github/mag0716/memorytraining/view/ListView.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/view/ListView.java
@@ -2,7 +2,7 @@ package com.github.mag0716.memorytraining.view;
 
 import android.support.annotation.NonNull;
 
-import com.github.mag0716.memorytraining.viewmodel.ListViewModel;
+import com.github.mag0716.memorytraining.model.Memory;
 
 import java.util.List;
 
@@ -16,9 +16,16 @@ public interface ListView extends IView {
     /**
      * 訓練対象データを表示
      *
-     * @param viewModelList 訓練対象データ一覧
+     * @param memoryList 訓練対象データ一覧
      */
-    void showMemoryList(@NonNull List<ListViewModel> viewModelList);
+    void showMemoryList(@NonNull List<Memory> memoryList);
+
+    /**
+     * 訓練対象データを非表示にする
+     *
+     * @param id Memory#id
+     */
+    void dismissMemory(long id);
 
     /**
      * 訓練完了

--- a/app/src/main/java/com/github/mag0716/memorytraining/view/ListView.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/view/ListView.java
@@ -1,0 +1,27 @@
+package com.github.mag0716.memorytraining.view;
+
+import android.support.annotation.NonNull;
+
+import com.github.mag0716.memorytraining.viewmodel.ListViewModel;
+
+import java.util.List;
+
+/**
+ * 一覧画面の View インタフェース
+ * <p>
+ * Created by mag0716 on 2017/06/19.
+ */
+public interface ListView extends IView {
+
+    /**
+     * 訓練対象データを表示
+     *
+     * @param viewModelList 訓練対象データ一覧
+     */
+    void showMemoryList(@NonNull List<ListViewModel> viewModelList);
+
+    /**
+     * 訓練完了
+     */
+    void completedTraining();
+}

--- a/app/src/main/java/com/github/mag0716/memorytraining/view/adapter/MemoryListAdapter.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/view/adapter/MemoryListAdapter.java
@@ -40,6 +40,11 @@ public class MemoryListAdapter extends RecyclerView.Adapter<MemoryListAdapter.Me
         // TODO: setVariable & executePendingBindings
         final Memory memory = memoryList.get(position);
         ((ViewListItemBinding) viewHolder.binding).questionText.setText(memory.getQuestion());
+        ((ViewListItemBinding) viewHolder.binding).answerText.setText(memory.getAnswer());
+        ((ViewListItemBinding) viewHolder.binding).openAndCloseIcon.setOnClickListener(v -> {
+            final View answerGroup = ((ViewListItemBinding) viewHolder.binding).answerGroup;
+            answerGroup.setVisibility(answerGroup.getVisibility() == View.VISIBLE ? View.GONE : View.VISIBLE);
+        });
     }
 
     @Override

--- a/app/src/main/java/com/github/mag0716/memorytraining/view/adapter/MemoryListAdapter.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/view/adapter/MemoryListAdapter.java
@@ -1,0 +1,68 @@
+package com.github.mag0716.memorytraining.view.adapter;
+
+import android.content.Context;
+import android.databinding.DataBindingUtil;
+import android.databinding.ViewDataBinding;
+import android.support.annotation.NonNull;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.github.mag0716.memorytraining.R;
+import com.github.mag0716.memorytraining.databinding.ViewListItemBinding;
+import com.github.mag0716.memorytraining.model.Memory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.Getter;
+
+/**
+ * Created by mag0716 on 2017/06/13.
+ */
+public class MemoryListAdapter extends RecyclerView.Adapter<MemoryListAdapter.MemoryViewHolder> {
+
+    private final LayoutInflater inflater;
+    private List<Memory> memoryList = new ArrayList<>();
+
+    public MemoryListAdapter(@NonNull Context context) {
+        inflater = LayoutInflater.from(context);
+    }
+
+    @Override
+    public MemoryViewHolder onCreateViewHolder(ViewGroup viewGroup, int position) {
+        return new MemoryViewHolder(inflater.inflate(R.layout.view_list_item, viewGroup, false));
+    }
+
+    @Override
+    public void onBindViewHolder(MemoryViewHolder viewHolder, int position) {
+        // TODO: setVariable & executePendingBindings
+        final Memory memory = memoryList.get(position);
+        ((ViewListItemBinding) viewHolder.binding).questionText.setText(memory.getQuestion());
+    }
+
+    @Override
+    public int getItemCount() {
+        return memoryList.size();
+    }
+
+    public void addAll(List<Memory> memoryList) {
+        this.memoryList.clear();
+        if (memoryList != null) {
+            this.memoryList.addAll(memoryList);
+            notifyDataSetChanged();
+        }
+    }
+
+    public class MemoryViewHolder extends RecyclerView.ViewHolder {
+
+        @Getter
+        private final ViewDataBinding binding;
+
+        public MemoryViewHolder(View itemView) {
+            super(itemView);
+            binding = DataBindingUtil.bind(itemView);
+        }
+    }
+}

--- a/app/src/main/java/com/github/mag0716/memorytraining/view/adapter/MemoryListAdapter.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/view/adapter/MemoryListAdapter.java
@@ -40,10 +40,6 @@ public class MemoryListAdapter extends RecyclerView.Adapter<MemoryListAdapter.Me
         final ListItemViewModel viewModel = viewModelList.get(position);
         ((ViewListItemBinding) viewHolder.binding).setMemory(viewModel);
         viewHolder.binding.executePendingBindings();
-        ((ViewListItemBinding) viewHolder.binding).openAndCloseIcon.setOnClickListener(v -> {
-            final View answerGroup = ((ViewListItemBinding) viewHolder.binding).answerGroup;
-            answerGroup.setVisibility(answerGroup.getVisibility() == View.VISIBLE ? View.GONE : View.VISIBLE);
-        });
     }
 
     @Override

--- a/app/src/main/java/com/github/mag0716/memorytraining/view/adapter/MemoryListAdapter.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/view/adapter/MemoryListAdapter.java
@@ -11,7 +11,7 @@ import android.view.ViewGroup;
 
 import com.github.mag0716.memorytraining.R;
 import com.github.mag0716.memorytraining.databinding.ViewListItemBinding;
-import com.github.mag0716.memorytraining.model.Memory;
+import com.github.mag0716.memorytraining.viewmodel.ListItemViewModel;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,7 +24,7 @@ import lombok.Getter;
 public class MemoryListAdapter extends RecyclerView.Adapter<MemoryListAdapter.MemoryViewHolder> {
 
     private final LayoutInflater inflater;
-    private List<Memory> memoryList = new ArrayList<>();
+    private List<ListItemViewModel> viewModelList = new ArrayList<>();
 
     public MemoryListAdapter(@NonNull Context context) {
         inflater = LayoutInflater.from(context);
@@ -37,10 +37,9 @@ public class MemoryListAdapter extends RecyclerView.Adapter<MemoryListAdapter.Me
 
     @Override
     public void onBindViewHolder(MemoryViewHolder viewHolder, int position) {
-        // TODO: setVariable & executePendingBindings
-        final Memory memory = memoryList.get(position);
-        ((ViewListItemBinding) viewHolder.binding).questionText.setText(memory.getQuestion());
-        ((ViewListItemBinding) viewHolder.binding).answerText.setText(memory.getAnswer());
+        final ListItemViewModel viewModel = viewModelList.get(position);
+        ((ViewListItemBinding) viewHolder.binding).setMemory(viewModel);
+        viewHolder.binding.executePendingBindings();
         ((ViewListItemBinding) viewHolder.binding).openAndCloseIcon.setOnClickListener(v -> {
             final View answerGroup = ((ViewListItemBinding) viewHolder.binding).answerGroup;
             answerGroup.setVisibility(answerGroup.getVisibility() == View.VISIBLE ? View.GONE : View.VISIBLE);
@@ -49,13 +48,13 @@ public class MemoryListAdapter extends RecyclerView.Adapter<MemoryListAdapter.Me
 
     @Override
     public int getItemCount() {
-        return memoryList.size();
+        return viewModelList.size();
     }
 
-    public void addAll(List<Memory> memoryList) {
-        this.memoryList.clear();
-        if (memoryList != null) {
-            this.memoryList.addAll(memoryList);
+    public void addAll(List<ListItemViewModel> viewModelList) {
+        this.viewModelList.clear();
+        if (viewModelList != null) {
+            this.viewModelList.addAll(viewModelList);
             notifyDataSetChanged();
         }
     }

--- a/app/src/main/java/com/github/mag0716/memorytraining/view/adapter/MemoryListAdapter.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/view/adapter/MemoryListAdapter.java
@@ -15,6 +15,7 @@ import com.github.mag0716.memorytraining.presenter.ListPresenter;
 import com.github.mag0716.memorytraining.viewmodel.ListItemViewModel;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 import lombok.Getter;
@@ -57,6 +58,18 @@ public class MemoryListAdapter extends RecyclerView.Adapter<MemoryListAdapter.Me
             this.viewModelList.addAll(viewModelList);
             notifyDataSetChanged();
         }
+    }
+
+    public void remove(long id) {
+        Iterator<ListItemViewModel> iterator = viewModelList.iterator();
+        while (iterator.hasNext()) {
+            ListItemViewModel viewModel = iterator.next();
+            if (viewModel.getId() == id) {
+                iterator.remove();
+                break;
+            }
+        }
+        notifyDataSetChanged();
     }
 
     public class MemoryViewHolder extends RecyclerView.ViewHolder {

--- a/app/src/main/java/com/github/mag0716/memorytraining/view/adapter/MemoryListAdapter.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/view/adapter/MemoryListAdapter.java
@@ -11,6 +11,7 @@ import android.view.ViewGroup;
 
 import com.github.mag0716.memorytraining.R;
 import com.github.mag0716.memorytraining.databinding.ViewListItemBinding;
+import com.github.mag0716.memorytraining.presenter.ListPresenter;
 import com.github.mag0716.memorytraining.viewmodel.ListItemViewModel;
 
 import java.util.ArrayList;
@@ -24,10 +25,12 @@ import lombok.Getter;
 public class MemoryListAdapter extends RecyclerView.Adapter<MemoryListAdapter.MemoryViewHolder> {
 
     private final LayoutInflater inflater;
+    private final ListPresenter presenter;
     private List<ListItemViewModel> viewModelList = new ArrayList<>();
 
-    public MemoryListAdapter(@NonNull Context context) {
+    public MemoryListAdapter(@NonNull Context context, @NonNull ListPresenter presenter) {
         inflater = LayoutInflater.from(context);
+        this.presenter = presenter;
     }
 
     @Override
@@ -39,6 +42,7 @@ public class MemoryListAdapter extends RecyclerView.Adapter<MemoryListAdapter.Me
     public void onBindViewHolder(MemoryViewHolder viewHolder, int position) {
         final ListItemViewModel viewModel = viewModelList.get(position);
         ((ViewListItemBinding) viewHolder.binding).setMemory(viewModel);
+        ((ViewListItemBinding) viewHolder.binding).setPresenter(presenter);
         viewHolder.binding.executePendingBindings();
     }
 

--- a/app/src/main/java/com/github/mag0716/memorytraining/view/decoration/CardItemDecoration.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/view/decoration/CardItemDecoration.java
@@ -1,0 +1,31 @@
+package com.github.mag0716.memorytraining.view.decoration;
+
+import android.content.Context;
+import android.graphics.Rect;
+import android.support.annotation.NonNull;
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+
+import com.github.mag0716.memorytraining.R;
+
+/**
+ * Created by mag0716 on 2017/06/14.
+ */
+public class CardItemDecoration extends RecyclerView.ItemDecoration {
+
+    private final Context context;
+    private final int verticalSpace;
+    private final int topPadding;
+
+    public CardItemDecoration(@NonNull Context context) {
+        this.context = context;
+        topPadding = context.getResources().getDimensionPixelOffset(R.dimen.lists_top_padding);
+        verticalSpace = context.getResources().getDimensionPixelOffset(R.dimen.cards_vertical_margin);
+    }
+
+    @Override
+    public void getItemOffsets(Rect outRect, View view, RecyclerView parent, RecyclerView.State state) {
+        final int position = parent.getChildAdapterPosition(view);
+        outRect.set(0, position == 0 ? topPadding : 0, 0, verticalSpace);
+    }
+}

--- a/app/src/main/java/com/github/mag0716/memorytraining/viewmodel/ListItemViewModel.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/viewmodel/ListItemViewModel.java
@@ -2,9 +2,11 @@ package com.github.mag0716.memorytraining.viewmodel;
 
 import android.databinding.BaseObservable;
 import android.databinding.Bindable;
+import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
 
 import com.github.mag0716.memorytraining.BR;
+import com.github.mag0716.memorytraining.R;
 import com.github.mag0716.memorytraining.model.Memory;
 
 /**
@@ -37,9 +39,16 @@ public class ListItemViewModel extends BaseObservable {
     public void setShowingAnswer(boolean showingAnswer) {
         isShowingAnswer = showingAnswer;
         notifyPropertyChanged(BR.showingAnswer);
+        notifyPropertyChanged(BR.openAndCloseIcon);
     }
 
     public void toggleShowingAnswer() {
         setShowingAnswer(!isShowingAnswer);
+    }
+
+    @DrawableRes
+    @Bindable
+    public int getOpenAndCloseIcon() {
+        return isShowingAnswer ? R.drawable.ic_arrow_up_black_24dp : R.drawable.ic_arrow_down_black_24dp;
     }
 }

--- a/app/src/main/java/com/github/mag0716/memorytraining/viewmodel/ListItemViewModel.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/viewmodel/ListItemViewModel.java
@@ -1,0 +1,41 @@
+package com.github.mag0716.memorytraining.viewmodel;
+
+import android.databinding.BaseObservable;
+import android.databinding.Bindable;
+import android.support.annotation.NonNull;
+
+import com.github.mag0716.memorytraining.BR;
+import com.github.mag0716.memorytraining.model.Memory;
+
+/**
+ * Created by mag0716 on 2017/06/16.
+ */
+public class ListItemViewModel extends BaseObservable {
+
+    private final String question;
+    private final String answer;
+    private boolean isShowingAnswer = false;
+
+    public ListItemViewModel(@NonNull Memory memory) {
+        question = memory.getQuestion();
+        answer = memory.getAnswer();
+    }
+
+    public String getQuestion() {
+        return question;
+    }
+
+    public String getAnswer() {
+        return answer;
+    }
+
+    @Bindable
+    public boolean isShowingAnswer() {
+        return isShowingAnswer;
+    }
+
+    public void setShowingAnswer(boolean showingAnswer) {
+        isShowingAnswer = showingAnswer;
+        notifyPropertyChanged(BR.showingAnswer);
+    }
+}

--- a/app/src/main/java/com/github/mag0716/memorytraining/viewmodel/ListItemViewModel.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/viewmodel/ListItemViewModel.java
@@ -38,4 +38,8 @@ public class ListItemViewModel extends BaseObservable {
         isShowingAnswer = showingAnswer;
         notifyPropertyChanged(BR.showingAnswer);
     }
+
+    public void toggleShowingAnswer() {
+        setShowingAnswer(!isShowingAnswer);
+    }
 }

--- a/app/src/main/java/com/github/mag0716/memorytraining/viewmodel/ListItemViewModel.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/viewmodel/ListItemViewModel.java
@@ -14,13 +14,19 @@ import com.github.mag0716.memorytraining.model.Memory;
  */
 public class ListItemViewModel extends BaseObservable {
 
+    private final long id;
     private final String question;
     private final String answer;
     private boolean isShowingAnswer = false;
 
     public ListItemViewModel(@NonNull Memory memory) {
+        id = memory.getId();
         question = memory.getQuestion();
         answer = memory.getAnswer();
+    }
+
+    public long getId() {
+        return id;
     }
 
     public String getQuestion() {

--- a/app/src/main/java/com/github/mag0716/memorytraining/viewmodel/ListViewModel.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/viewmodel/ListViewModel.java
@@ -2,12 +2,15 @@ package com.github.mag0716.memorytraining.viewmodel;
 
 import android.databinding.BaseObservable;
 import android.databinding.Bindable;
+import android.support.annotation.StringRes;
 
 import com.annimon.stream.Stream;
 import com.github.mag0716.memorytraining.BR;
+import com.github.mag0716.memorytraining.R;
 import com.github.mag0716.memorytraining.model.Memory;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -30,6 +33,19 @@ public class ListViewModel extends BaseObservable {
         notifyPropertyChanged(BR.completed);
     }
 
+    public void remove(long id) {
+        Iterator<ListItemViewModel> iterator = itemViewModelList.iterator();
+        while (iterator.hasNext()) {
+            ListItemViewModel viewModel = iterator.next();
+            if (viewModel.getId() == id) {
+                iterator.remove();
+                break;
+            }
+        }
+        isCompleted = itemViewModelList.isEmpty();
+        notifyPropertyChanged(BR.completed);
+    }
+
     public List<ListItemViewModel> getItemViewModelList() {
         return itemViewModelList;
     }
@@ -37,5 +53,12 @@ public class ListViewModel extends BaseObservable {
     @Bindable
     public boolean isCompleted() {
         return isCompleted;
+    }
+
+    @StringRes
+    @Bindable
+    public int getInformationMessageId() {
+        // TODO: DB にデータが1件もない場合は別のメッセージにする
+        return R.string.list_completed_training_message;
     }
 }

--- a/app/src/main/java/com/github/mag0716/memorytraining/viewmodel/ListViewModel.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/viewmodel/ListViewModel.java
@@ -1,0 +1,41 @@
+package com.github.mag0716.memorytraining.viewmodel;
+
+import android.databinding.BaseObservable;
+import android.databinding.Bindable;
+
+import com.annimon.stream.Stream;
+import com.github.mag0716.memorytraining.BR;
+import com.github.mag0716.memorytraining.model.Memory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by mag0716 on 2017/06/16.
+ */
+
+public class ListViewModel extends BaseObservable {
+
+    private final List<ListItemViewModel> itemViewModelList = new ArrayList<>();
+    private boolean isCompleted = false;
+
+    // TODO: Memory の追加、削除
+    public void addAll(List<Memory> memoryList) {
+        if (memoryList != null) {
+            itemViewModelList.addAll(Stream.of(memoryList)
+                    .map(ListItemViewModel::new)
+                    .toList());
+        }
+        isCompleted = itemViewModelList.isEmpty();
+        notifyPropertyChanged(BR.completed);
+    }
+
+    public List<ListItemViewModel> getItemViewModelList() {
+        return itemViewModelList;
+    }
+
+    @Bindable
+    public boolean isCompleted() {
+        return isCompleted;
+    }
+}

--- a/app/src/main/res/drawable/ic_arrow_down_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_arrow_down_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M7.41,7.84L12,12.42l4.59,-4.58L18,9.25l-6,6 -6,-6z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_arrow_up_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_arrow_up_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M7.41,15.41L12,10.83l4.59,4.58L18,14l-6,-6 -6,6z"/>
+</vector>

--- a/app/src/main/res/layout/activity_list.xml
+++ b/app/src/main/res/layout/activity_list.xml
@@ -1,33 +1,38 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context="com.github.mag0716.memorytraining.activity.ListActivity">
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <android.support.design.widget.AppBarLayout
+    <android.support.design.widget.CoordinatorLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:theme="@style/AppTheme.AppBarOverlay">
+        android:layout_height="match_parent"
+        tools:context="com.github.mag0716.memorytraining.activity.ListActivity">
 
-        <android.support.v7.widget.Toolbar
-            android:id="@+id/toolbar"
+        <android.support.design.widget.AppBarLayout
             android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize"
-            android:background="?attr/colorPrimary"
-            app:popupTheme="@style/AppTheme.PopupOverlay" />
+            android:layout_height="wrap_content"
+            android:theme="@style/AppTheme.AppBarOverlay">
 
-    </android.support.design.widget.AppBarLayout>
+            <android.support.v7.widget.Toolbar
+                android:id="@+id/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                android:background="?attr/colorPrimary"
+                app:popupTheme="@style/AppTheme.PopupOverlay" />
 
-    <include layout="@layout/content_list" />
+        </android.support.design.widget.AppBarLayout>
 
-    <android.support.design.widget.FloatingActionButton
-        android:id="@+id/fab"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="bottom|end"
-        android:layout_margin="@dimen/fab_margin"
-        app:srcCompat="@android:drawable/ic_dialog_email" />
+        <include
+            android:id="@+id/content"
+            layout="@layout/content_list" />
 
-</android.support.design.widget.CoordinatorLayout>
+        <android.support.design.widget.FloatingActionButton
+            android:id="@+id/fab"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom|end"
+            android:layout_margin="@dimen/fab_margin"
+            app:srcCompat="@android:drawable/ic_dialog_email" />
+
+    </android.support.design.widget.CoordinatorLayout>
+</layout>

--- a/app/src/main/res/layout/activity_list.xml
+++ b/app/src/main/res/layout/activity_list.xml
@@ -3,6 +3,13 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <data>
+
+        <variable
+            name="presenter"
+            type="com.github.mag0716.memorytraining.presenter.ListPresenter" />
+    </data>
+
     <android.support.design.widget.CoordinatorLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -32,6 +39,7 @@
             android:layout_height="wrap_content"
             android:layout_gravity="bottom|end"
             android:layout_margin="@dimen/fab_margin"
+            android:onClick="@{() -> presenter.addMemory()}"
             app:srcCompat="@android:drawable/ic_dialog_email" />
 
     </android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/content_list.xml
+++ b/app/src/main/res/layout/content_list.xml
@@ -3,6 +3,13 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <data>
+
+        <variable
+            name="viewModel"
+            type="com.github.mag0716.memorytraining.viewmodel.ListViewModel" />
+    </data>
+
     <android.support.constraint.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -17,7 +24,20 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent"
+            app:visibleOrGone="@{!viewModel.isCompleted}" />
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:text="@{viewModel.informationMessageId}"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:visibleOrGone="@{viewModel.isCompleted}"
+            tools:text="@string/list_completed_training_message" />
 
     </android.support.constraint.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/content_list.xml
+++ b/app/src/main/res/layout/content_list.xml
@@ -1,20 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    app:layout_behavior="@string/appbar_scrolling_view_behavior"
-    tools:context="com.github.mag0716.memorytraining.activity.ListActivity"
-    tools:showIn="@layout/activity_list">
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Hello World!"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+    <android.support.constraint.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        tools:context="com.github.mag0716.memorytraining.activity.ListActivity"
+        tools:showIn="@layout/activity_list">
 
-</android.support.constraint.ConstraintLayout>
+        <android.support.v7.widget.RecyclerView
+            android:id="@+id/trainingList"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </android.support.constraint.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/view_list_item.xml
+++ b/app/src/main/res/layout/view_list_item.xml
@@ -8,6 +8,10 @@
         <variable
             name="memory"
             type="com.github.mag0716.memorytraining.viewmodel.ListItemViewModel" />
+
+        <variable
+            name="presenter"
+            type="com.github.mag0716.memorytraining.presenter.ListPresenter" />
     </data>
 
     <android.support.v7.widget.CardView
@@ -63,6 +67,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="@dimen/cards_action_button_row_padding"
                 android:layout_marginStart="@dimen/cards_action_button_row_padding"
+                android:onClick="@{() -> presenter.levelUp(memory.getId())}"
                 android:text="OK"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toStartOf="@+id/ng_button"
@@ -76,6 +81,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/cards_action_button_row_padding"
+                android:onClick="@{() -> presenter.levelDown(memory.getId())}"
                 android:text="NG"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/view_list_item.xml
+++ b/app/src/main/res/layout/view_list_item.xml
@@ -84,9 +84,8 @@
                 android:id="@+id/answer_group"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:visibility="gone"
                 app:constraint_referenced_ids="answer_text"
-                tools:visibility="visible" />
+                app:visibleOrGone="@{memory.isShowingAnswer}" />
 
         </android.support.constraint.ConstraintLayout>
 

--- a/app/src/main/res/layout/view_list_item.xml
+++ b/app/src/main/res/layout/view_list_item.xml
@@ -3,6 +3,13 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <data>
+
+        <variable
+            name="memory"
+            type="com.github.mag0716.memorytraining.viewmodel.ListItemViewModel" />
+    </data>
+
     <android.support.v7.widget.CardView
         android:id="@+id/memory_card"
         style="@style/AppTheme.Card"
@@ -20,6 +27,7 @@
                 style="@style/AppTheme.Card.Title"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
+                android:text="@{memory.question}"
                 app:layout_constraintEnd_toStartOf="@id/open_and_close_icon"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/answer_text"
@@ -41,6 +49,7 @@
                 style="@style/AppTheme.Card.SubText"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
+                android:text="@{memory.answer}"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/question_text"

--- a/app/src/main/res/layout/view_list_item.xml
+++ b/app/src/main/res/layout/view_list_item.xml
@@ -4,11 +4,12 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <android.support.v7.widget.CardView
-        style="@style/CardView.Light"
+        android:id="@+id/memory_card"
+        style="@style/AppTheme.Card"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginLeft="@dimen/cards_horizontal_margin"
-        android:layout_marginRight="@dimen/cards_horizontal_margin">
+        android:layout_marginEnd="@dimen/cards_horizontal_margin"
+        android:layout_marginStart="@dimen/cards_horizontal_margin">
 
         <android.support.constraint.ConstraintLayout
             android:layout_width="match_parent"
@@ -16,59 +17,66 @@
 
             <TextView
                 android:id="@+id/question_text"
+                style="@style/AppTheme.Card.Title"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toLeftOf="@+id/arrow_icon"
-                app:layout_constraintTop_toBottomOf="@+id/answer_text"
+                app:layout_constraintEnd_toStartOf="@id/open_and_close_icon"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/answer_text"
                 app:layout_constraintTop_toTopOf="parent"
                 tools:text="access" />
 
             <ImageView
-                android:id="@id/arrow_icon"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:layout_constraintRight_toRightOf="parent"
+                android:id="@+id/open_and_close_icon"
+                style="@style/AppTheme.Card.Action"
+                android:layout_width="@dimen/touch_target_minimum_size"
+                android:layout_height="@dimen/touch_target_minimum_size"
+                android:layout_marginEnd="@dimen/cards_action_button_row_padding"
+                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
                 app:srcCompat="@drawable/ic_arrow_down_black_24dp" />
 
             <TextView
                 android:id="@+id/answer_text"
+                style="@style/AppTheme.Card.SubText"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/question_text"
                 tools:text="アクセス、通行権" />
 
             <Button
                 android:id="@+id/ok_button"
-                style="?android:attr/borderlessButtonStyle"
+                style="@style/AppTheme.Card.Action"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_marginEnd="@dimen/cards_action_button_row_padding"
+                android:layout_marginStart="@dimen/cards_action_button_row_padding"
                 android:text="OK"
                 app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@+id/ng_button"
                 app:layout_constraintHorizontal_bias="1"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toLeftOf="@+id/ng_button"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/answer_text" />
 
             <Button
                 android:id="@+id/ng_button"
-                style="?android:attr/borderlessButtonStyle"
+                style="@style/AppTheme.Card.Action"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/cards_action_button_row_padding"
                 android:text="NG"
                 app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/answer_text" />
 
             <android.support.constraint.Group
                 android:id="@+id/answer_group"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                app:constraint_referenced_ids="answer_text,ok_button,ng_button"
+                android:visibility="gone"
+                app:constraint_referenced_ids="answer_text"
                 tools:visibility="visible" />
 
         </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/view_list_item.xml
+++ b/app/src/main/res/layout/view_list_item.xml
@@ -43,7 +43,7 @@
                 android:onClick="@{() -> memory.toggleShowingAnswer()}"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
-                app:srcCompat="@drawable/ic_arrow_down_black_24dp" />
+                app:srcCompat="@{memory.openAndCloseIcon}" />
 
             <TextView
                 android:id="@+id/answer_text"

--- a/app/src/main/res/layout/view_list_item.xml
+++ b/app/src/main/res/layout/view_list_item.xml
@@ -40,6 +40,7 @@
                 android:layout_width="@dimen/touch_target_minimum_size"
                 android:layout_height="@dimen/touch_target_minimum_size"
                 android:layout_marginEnd="@dimen/cards_action_button_row_padding"
+                android:onClick="@{() -> memory.toggleShowingAnswer()}"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
                 app:srcCompat="@drawable/ic_arrow_down_black_24dp" />

--- a/app/src/main/res/layout/view_list_item.xml
+++ b/app/src/main/res/layout/view_list_item.xml
@@ -4,8 +4,11 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <android.support.v7.widget.CardView
+        style="@style/CardView.Light"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="@dimen/cards_horizontal_margin"
+        android:layout_marginRight="@dimen/cards_horizontal_margin">
 
         <android.support.constraint.ConstraintLayout
             android:layout_width="match_parent"
@@ -15,9 +18,9 @@
                 android:id="@+id/question_text"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                app:layout_constraintBottom_toTopOf="@+id/answer_container"
                 app:layout_constraintLeft_toLeftOf="parent"
                 app:layout_constraintRight_toLeftOf="@+id/arrow_icon"
+                app:layout_constraintTop_toBottomOf="@+id/answer_text"
                 app:layout_constraintTop_toTopOf="parent"
                 tools:text="access" />
 
@@ -29,41 +32,44 @@
                 app:layout_constraintTop_toTopOf="parent"
                 app:srcCompat="@drawable/ic_arrow_down_black_24dp" />
 
-            <RelativeLayout
-                android:id="@id/answer_container"
+            <TextView
+                android:id="@+id/answer_text"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                app:layout_constraintBottom_toBottomOf="parent"
+                android:layout_marginTop="8dp"
                 app:layout_constraintLeft_toLeftOf="parent"
                 app:layout_constraintRight_toRightOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/question_text">
+                app:layout_constraintTop_toBottomOf="@+id/question_text"
+                tools:text="アクセス、通行権" />
 
-                <TextView
-                    android:id="@+id/answer_text"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    tools:text="アクセス、通行権" />
+            <Button
+                android:id="@+id/ok_button"
+                style="?android:attr/borderlessButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="OK"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintHorizontal_bias="1"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintRight_toLeftOf="@+id/ng_button"
+                app:layout_constraintTop_toBottomOf="@id/answer_text" />
 
-                <Button
-                    android:id="@+id/ok_button"
-                    style="?android:attr/borderlessButtonStyle"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_alignParentRight="true"
-                    android:layout_below="@id/answer_text"
-                    android:text="OK" />
+            <Button
+                android:id="@+id/ng_button"
+                style="?android:attr/borderlessButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="NG"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/answer_text" />
 
-                <Button
-                    android:id="@+id/ng_button"
-                    style="?android:attr/borderlessButtonStyle"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_alignTop="@id/ok_button"
-                    android:layout_toLeftOf="@id/ok_button"
-                    android:text="NG" />
-
-
-            </RelativeLayout>
+            <android.support.constraint.Group
+                android:id="@+id/answer_group"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:constraint_referenced_ids="answer_text,ok_button,ng_button"
+                tools:visibility="visible" />
 
         </android.support.constraint.ConstraintLayout>
 

--- a/app/src/main/res/layout/view_list_item.xml
+++ b/app/src/main/res/layout/view_list_item.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <android.support.v7.widget.CardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <android.support.constraint.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:id="@+id/question_text"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                app:layout_constraintBottom_toTopOf="@+id/answer_container"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintRight_toLeftOf="@+id/arrow_icon"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="access" />
+
+            <ImageView
+                android:id="@id/arrow_icon"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:srcCompat="@drawable/ic_arrow_down_black_24dp" />
+
+            <RelativeLayout
+                android:id="@id/answer_container"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/question_text">
+
+                <TextView
+                    android:id="@+id/answer_text"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    tools:text="アクセス、通行権" />
+
+                <Button
+                    android:id="@+id/ok_button"
+                    style="?android:attr/borderlessButtonStyle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentRight="true"
+                    android:layout_below="@id/answer_text"
+                    android:text="OK" />
+
+                <Button
+                    android:id="@+id/ng_button"
+                    style="?android:attr/borderlessButtonStyle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignTop="@id/ok_button"
+                    android:layout_toLeftOf="@id/ok_button"
+                    android:text="NG" />
+
+
+            </RelativeLayout>
+
+        </android.support.constraint.ConstraintLayout>
+
+    </android.support.v7.widget.CardView>
+</layout>

--- a/app/src/main/res/values/dimens_material.xml
+++ b/app/src/main/res/values/dimens_material.xml
@@ -1,6 +1,21 @@
 <resources>
 
-    <!-- Cards(https://material.io/guidelines/components/cards.html)-->
+    <!-- Buttons(https://material.io/guidelines/components/buttons.html) -->
+    <dimen name="buttons_minimum_width">88dp</dimen>
+    <dimen name="buttons_minimum_height">36dp</dimen>
+    <dimen name="buttons_minimum_touchable_target_height">48dp</dimen>
+    <dimen name="buttons_corner_radius">2dp</dimen>
+    <dimen name="buttons_text_size">14sp</dimen>
+    <dimen name="buttons_horizontal_padding">16dp</dimen>
+    <dimen name="buttons_dense_text_size">13sp</dimen>
+    <dimen name="buttons_dense_minimum_height">32dp</dimen>
+    <dimen name="buttons_raised_elevation">2dp</dimen>
+
+    <!-- Lists(https://material.io/guidelines/components/lists.html) -->
+    <dimen name="lists_top_padding">8dp</dimen>
+    <dimen name="lists_dense_top_padding">4dp</dimen>
+
+    <!-- Cards(https://material.io/guidelines/components/cards.html) -->
     <dimen name="cards_primary_title_top_padding">24dp</dimen>
     <dimen name="cards_primary_title_bottom_padding">16dp</dimen>
     <dimen name="cards_action_button_row_padding">8dp</dimen>
@@ -18,6 +33,8 @@
     <dimen name="cards_supporting_text_horizontal_padding">16dp</dimen>
     <!-- if there are additional actions or text below -->
     <dimen name="cards_supporting_text_small_bottom_padding">16dp</dimen>
+    <dimen name="cards_horizontal_margin">8dp</dimen>
+    <dimen name="cards_vertical_margin">8dp</dimen>
     <dimen name="cards_elevation">2dp</dimen>
     <dimen name="cards_elevation_raised">8dp</dimen>
 </resources>

--- a/app/src/main/res/values/dimens_material.xml
+++ b/app/src/main/res/values/dimens_material.xml
@@ -1,0 +1,23 @@
+<resources>
+
+    <!-- Cards(https://material.io/guidelines/components/cards.html)-->
+    <dimen name="cards_primary_title_top_padding">24dp</dimen>
+    <dimen name="cards_primary_title_bottom_padding">16dp</dimen>
+    <dimen name="cards_action_button_row_padding">8dp</dimen>
+    <dimen name="cards_supporting_text_top_padding">16dp</dimen>
+    <dimen name="cards_supporting_text_bottom_padding">24dp</dimen>
+    <dimen name="cards_primary_title_text_size">24sp</dimen>
+    <dimen name="cards_primary_title_small_text_size">14sp</dimen>
+    <dimen name="cards_sub_title_text_size">14sp</dimen>
+    <dimen name="cards_primary_title_horizontal_padding">16dp</dimen>
+    <!-- when a small primary title is present -->
+    <dimen name="cards_primary_title_small_top_padding">16dp</dimen>
+    <!-- no actions or supporting text -->
+    <dimen name="cards_primary_title_large_bottom_padding">24dp</dimen>
+    <dimen name="cards_supporting_text_size">14sp</dimen>
+    <dimen name="cards_supporting_text_horizontal_padding">16dp</dimen>
+    <!-- if there are additional actions or text below -->
+    <dimen name="cards_supporting_text_small_bottom_padding">16dp</dimen>
+    <dimen name="cards_elevation">2dp</dimen>
+    <dimen name="cards_elevation_raised">8dp</dimen>
+</resources>

--- a/app/src/main/res/values/dimens_material.xml
+++ b/app/src/main/res/values/dimens_material.xml
@@ -1,5 +1,8 @@
 <resources>
 
+    <!-- Metrics(https://material.io/guidelines/layout/metrics-keylines.htm) -->
+    <dimen name="touch_target_minimum_size">48dp</dimen>
+
     <!-- Buttons(https://material.io/guidelines/components/buttons.html) -->
     <dimen name="buttons_minimum_width">88dp</dimen>
     <dimen name="buttons_minimum_height">36dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,7 @@
 <resources>
     <string name="app_name">MemoryTraining</string>
     <string name="action_settings">Settings</string>
+
+    <string name="list_empty_message">データがありません。\n追加画面より追加して訓練を始めましょう。</string>
+    <string name="list_completed_training_message">おめでとうございます!!\n全ての訓練が完了しました。</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -19,4 +19,27 @@
 
     <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
 
+    <style name="AppTheme.Card" parent="CardView.Light" />
+
+    <style name="AppTheme.Card.Title">
+        <item name="android:paddingTop">@dimen/cards_primary_title_top_padding</item>
+        <item name="android:paddingBottom">@dimen/cards_primary_title_bottom_padding</item>
+        <item name="android:paddingStart">@dimen/cards_primary_title_horizontal_padding</item>
+        <item name="android:paddingEnd">@dimen/cards_primary_title_horizontal_padding</item>
+        <item name="android:textSize">@dimen/cards_primary_title_text_size</item>
+        <item name="android:textColor">@color/primary_text</item>
+    </style>
+
+    <style name="AppTheme.Card.SubText">
+        <item name="android:paddingBottom">@dimen/cards_supporting_text_bottom_padding</item>
+        <item name="android:paddingStart">@dimen/cards_supporting_text_horizontal_padding</item>
+        <item name="android:paddingEnd">@dimen/cards_supporting_text_horizontal_padding</item>
+        <item name="android:textSize">@dimen/cards_supporting_text_size</item>
+        <item name="android:textColor">@color/primary_text</item>
+    </style>
+
+    <style name="AppTheme.Card.Action" parent="@style/Widget.AppCompat.Button.Borderless">
+        <item name="android:layout_marginTop">@dimen/cards_action_button_row_padding</item>
+        <item name="android:layout_marginBottom">@dimen/cards_action_button_row_padding</item>
+    </style>
 </resources>

--- a/app/src/test/kotlin/com/github/mag0716/memorytraining/model/LevelTest.kt
+++ b/app/src/test/kotlin/com/github/mag0716/memorytraining/model/LevelTest.kt
@@ -1,0 +1,51 @@
+package com.github.mag0716.memorytraining.model
+
+import org.hamcrest.core.Is.`is`
+import org.junit.Assert.assertThat
+import org.junit.Test
+
+/**
+ * Created by mag0716 on 2017/06/20.
+ */
+class LevelTest {
+
+    @Test
+    fun LEVEL1() {
+        assertThat(Level.LEVEL1.id, `is`(0))
+        assertThat(Level.LEVEL1.trainingInterval, `is`(30 * 1000L))
+        assertThat(Level.LEVEL1.getPreviousLevel(0), `is`(Level.LEVEL1))
+        assertThat(Level.LEVEL1.getNextLevel(0), `is`(Level.LEVEL2))
+    }
+
+    @Test
+    fun LEVEL2() {
+        assertThat(Level.LEVEL2.id, `is`(1))
+        assertThat(Level.LEVEL2.trainingInterval, `is`(3 * 60 * 1000L))
+        assertThat(Level.LEVEL2.getPreviousLevel(0), `is`(Level.LEVEL1))
+        assertThat(Level.LEVEL2.getNextLevel(0), `is`(Level.LEVEL3))
+    }
+
+    @Test
+    fun LEVEL3() {
+        assertThat(Level.LEVEL3.id, `is`(2))
+        assertThat(Level.LEVEL3.trainingInterval, `is`(1 * 60 * 60 * 1000L))
+        assertThat(Level.LEVEL3.getPreviousLevel(0), `is`(Level.LEVEL2))
+        assertThat(Level.LEVEL3.getNextLevel(0), `is`(Level.LEVEL4))
+    }
+
+    @Test
+    fun LEVEL4() {
+        assertThat(Level.LEVEL4.id, `is`(3))
+        assertThat(Level.LEVEL4.trainingInterval, `is`(1 * 24 * 60 * 60 * 1000L))
+        assertThat(Level.LEVEL4.getPreviousLevel(0), `is`(Level.LEVEL3))
+        assertThat(Level.LEVEL4.getNextLevel(0), `is`(Level.LEVEL5))
+    }
+
+    @Test
+    fun LEVEL5() {
+        assertThat(Level.LEVEL5.id, `is`(4))
+        assertThat(Level.LEVEL5.trainingInterval, `is`(30 * 24 * 60 * 60 * 1000L))
+        assertThat(Level.LEVEL5.getPreviousLevel(0), `is`(Level.LEVEL4))
+        assertThat(Level.LEVEL5.getNextLevel(0), `is`(Level.LEVEL5))
+    }
+}

--- a/app/src/test/kotlin/com/github/mag0716/memorytraining/model/MemoryTest.kt
+++ b/app/src/test/kotlin/com/github/mag0716/memorytraining/model/MemoryTest.kt
@@ -1,0 +1,47 @@
+package com.github.mag0716.memorytraining.model
+
+import org.hamcrest.core.Is.`is`
+import org.junit.Assert.assertThat
+import org.junit.Test
+
+/**
+ * Created by mag0716 on 2017/06/22.
+ */
+class MemoryTest {
+
+    @Test
+    fun levelUp_次のレベルに上がったらcountはクリアされていること() {
+        val memory = Memory(0, "question", "answer", 0, 1)
+        memory.levelUp(1)
+
+        assertThat(memory.level, `is`(1))
+        assertThat(memory.count, `is`(0))
+    }
+
+    @Test
+    fun levelUp_同じレベルだったらcountがインクリメントされていること() {
+        val memory = Memory(0, "question", "answer", 0, 0)
+        memory.levelUp(0)
+
+        assertThat(memory.level, `is`(0))
+        assertThat(memory.count, `is`(1))
+    }
+
+    @Test
+    fun levelDown_前のレベルに下がったらcountはクリアされていること() {
+        val memory = Memory(0, "question", "answer", 1, 0)
+        memory.levelDown(0)
+
+        assertThat(memory.level, `is`(0))
+        assertThat(memory.count, `is`(0))
+    }
+
+    @Test
+    fun levelDown_同じレベルだったらcountがクリアされていること() {
+        val memory = Memory(0, "question", "answer", 0, 1)
+        memory.levelDown(0)
+
+        assertThat(memory.level, `is`(0))
+        assertThat(memory.count, `is`(0))
+    }
+}


### PR DESCRIPTION
## Description

以下の条件のデータの一覧を表示する
切り替えは Toolbar の Spinner から行う

* 訓練対象のデータのみ(Memory.nextTrainingDatetime <= 現在日時)
* 登録してあるデータ

デフォルトは訓練対象のデータのみ

表示するデータは

* 質問
* 訓練レベル

セルタップで回答と OK, NG のボタンも表示する

OK ボタン -> 訓練レベル、次回訓練予定日時を更新して、一覧から削除
NG ボタン -> 訓練レベル、次回訓練予定日時を更新して、一覧の表示を更新

## TODO

- [x] 一覧画面のレイアウト
    - [x] 表示対象なし
    - [x] 表示対象あり
- [x] セルのレイアウト
- [x] セルタップ時の View の切り替え
    * アニメーションは後回し
- [x] ViewModel 作成
- [x] OK ボタンタップ時の処理
- [x] NG ボタンタップ時の処理
~~- [ ] Spinner でのカテゴリ切り替え~~
-> 別 Issue で実装する
~~- [ ] 一定間隔での一覧の更新~~
-> 定期実行タイミングで更新する

## Memo

* セルタップ時のアニメーション
    * https://developer.android.com/training/animation/cardflip.html
    * https://stackoverflow.com/questions/41464629/expand-collapse-animation-in-cardview
    * https://github.com/worldline/FoldableLayout

* 全て訓練が終わったタイミングに表示するとよさそう
    * https://github.com/DanielMartinus/konfetti

## Link