### PR TITLE
Android Architecture Components を 1.0.0-alpha3 にアップデート

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 def support_lib_version = "25.3.1"
-def arch_lib_version = "1.0.0-alpha2"
+def arch_lib_version = "1.0.0-alpha3"
 def leakcanary_version = "1.5"
 def permission_dispatcher_version = "2.3.2"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -85,4 +85,5 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
     testImplementation "android.arch.persistence.room:testing:${arch_lib_version}"
+    testImplementation 'com.github.gfx.android.robolectricinstrumentation:robolectric-instrumentation:3.1.4'
 }

--- a/app/src/test/kotlin/com/github/mag0716/memorytraining/repository/database/ApplicationDatabaseTest.kt
+++ b/app/src/test/kotlin/com/github/mag0716/memorytraining/repository/database/ApplicationDatabaseTest.kt
@@ -2,13 +2,13 @@ package com.github.mag0716.memorytraining.repository.database
 
 import android.arch.persistence.db.framework.FrameworkSQLiteOpenHelperFactory
 import android.arch.persistence.room.testing.MigrationTestHelper
+import android.support.test.InstrumentationRegistry
 import org.hamcrest.Matchers.`is`
 import org.junit.Assert.assertThat
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 
 /**
@@ -22,11 +22,9 @@ class ApplicationDatabaseTest {
 
     @Rule
     @JvmField
-    var helper = MigrationTestHelper(RuntimeEnvironment.application,
-            ApplicationDatabase::
-            class.java.canonicalName,
+    var helper = MigrationTestHelper(InstrumentationRegistry.getInstrumentation(),
+            ApplicationDatabase::class.java.canonicalName,
             FrameworkSQLiteOpenHelperFactory())
-
 
     @Test
     fun v1() {


### PR DESCRIPTION
## Description

Android Architecture Components を最新にアップデート

## TODO

* MigrationTestHelper の変更でテストコードへの影響がないことを確認する

## Link

* https://developer.android.com/topic/libraries/architecture/release-notes.html