### PR TITLE
定期実行

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'kotlin-android'
 
 def support_lib_version = "25.3.1"
 def arch_lib_version = "1.0.0-alpha3"
+def play_services_version = "11.0.1"
 def leakcanary_version = "1.5"
 def permission_dispatcher_version = "2.3.2"
 
@@ -56,6 +57,7 @@ dependencies {
     implementation 'com.android.support.constraint:constraint-layout:1.1.0-beta1'
     implementation "android.arch.persistence.room:runtime:${arch_lib_version}"
     annotationProcessor "android.arch.persistence.room:compiler:${arch_lib_version}"
+    implementation "com.google.android.gms:play-services-gcm:${play_services_version}"
 
     compileOnly "org.projectlombok:lombok:1.16.16"
     annotationProcessor "org.projectlombok:lombok:1.16.16"

--- a/app/src/debug/java/com/github/mag0716/memorytraining/DebugApplication.java
+++ b/app/src/debug/java/com/github/mag0716/memorytraining/DebugApplication.java
@@ -9,6 +9,7 @@ import com.facebook.stetho.Stetho;
 import com.github.mag0716.memorytraining.model.Memory;
 import com.github.mag0716.memorytraining.repository.database.ApplicationDatabase;
 import com.github.mag0716.memorytraining.repository.database.MemoryDao;
+import com.github.mag0716.memorytraining.service.TaskConductor;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
 import com.squareup.moshi.Types;
@@ -37,6 +38,7 @@ public class DebugApplication extends Application {
         super.onCreate();
         Stetho.initializeWithDefaults(this);
         initializeDatabaseForDebug(this);
+        TaskConductor.registerTaskIfNeeded(this, database.memoryDao());
     }
 
     private void initializeDatabaseForDebug(@NonNull Context context) {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.github.mag0716.memorytraining">
 
+    <permission android:name="android.Manifest.permission.RECEIVE_BOOT_COMPLETED" />
+
     <application
         android:name=".Application"
         android:allowBackup="true"
@@ -20,6 +22,16 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <service
+            android:name=".service.gcmnetworkmanager.GcmNetworkManagerService"
+            android:exported="true"
+            android:permission="com.google.android.gms.permission.BIND_NETWORK_TASK_SERVICE">
+            <intent-filter>
+                <action android:name="com.google.android.gms.gcm.ACTION_TASK_READY" />
+            </intent-filter>
+        </service>
+
     </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.github.mag0716.memorytraining">
 
-    <permission android:name="android.Manifest.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application
         android:name=".Application"
@@ -32,6 +32,14 @@
             </intent-filter>
         </service>
 
+        <receiver
+            android:name=".receiver.BootCompletedReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/github/mag0716/memorytraining/model/Memory.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/model/Memory.java
@@ -11,6 +11,10 @@ import android.provider.BaseColumns;
 import android.support.annotation.IntRange;
 import android.support.annotation.VisibleForTesting;
 
+import com.github.mag0716.memorytraining.util.DatetimeUtil;
+
+import java.util.Locale;
+
 /**
  * 訓練対象データ
  * <p>
@@ -46,6 +50,12 @@ public class Memory implements Parcelable {
      */
     private int count;
 
+    /**
+     * 次回訓練予定日時
+     */
+    @ColumnInfo(name = "next_training_datetime")
+    private long nextTrainingDatetime;
+
     @Ignore
     @VisibleForTesting
     public Memory(long id, String question, String answer, int level, int count) {
@@ -66,11 +76,6 @@ public class Memory implements Parcelable {
         this.count = count;
         this.nextTrainingDatetime = nextTrainingDatetime;
     }
-    /**
-     * 次回訓練予定日時
-     */
-    @ColumnInfo(name = "next_training_datetime")
-    private long nextTrainingDatetime;
 
     public long getId() {
         return id;
@@ -134,12 +139,21 @@ public class Memory implements Parcelable {
         this.level = nextLevel;
     }
 
+    @Override
+    public String toString() {
+        final String format = "Memory(id=%d, count=%d, level=%d, next training datetime=%s)";
+        return String.format(Locale.getDefault(),
+                format,
+                id,
+                count,
+                level,
+                DatetimeUtil.convertDebugFormat(nextTrainingDatetime));
+    }
+
     // region Parcelable
 
     public Memory() {
     }
-
-    // endregion
 
     @Override
     public int describeContents() {
@@ -176,4 +190,5 @@ public class Memory implements Parcelable {
             return new Memory[size];
         }
     };
+    // endregion
 }

--- a/app/src/main/java/com/github/mag0716/memorytraining/presenter/ListPresenter.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/presenter/ListPresenter.java
@@ -5,6 +5,7 @@ import android.support.annotation.NonNull;
 import com.github.mag0716.memorytraining.model.Level;
 import com.github.mag0716.memorytraining.model.Memory;
 import com.github.mag0716.memorytraining.repository.database.MemoryDao;
+import com.github.mag0716.memorytraining.service.TaskConductor;
 import com.github.mag0716.memorytraining.view.IView;
 import com.github.mag0716.memorytraining.view.ListView;
 
@@ -83,6 +84,7 @@ public class ListPresenter implements IPresenter {
                     memory.setNextTrainingDatetime(System.currentTimeMillis() + nextLevel.getTrainingInterval());
                     memory.levelUp(nextLevel.getId());
                     dao.update(memory);
+                    TaskConductor.registerTaskIfNeeded(view.getContext(), dao);
                     return memory;
                 })
                 .subscribeOn(Schedulers.io())
@@ -108,6 +110,7 @@ public class ListPresenter implements IPresenter {
                     memory.setNextTrainingDatetime(System.currentTimeMillis() + previousLevel.getTrainingInterval());
                     memory.levelDown(previousLevel.getId());
                     dao.update(memory);
+                    TaskConductor.registerTaskIfNeeded(view.getContext(), dao);
                     return memory;
                 })
                 .subscribeOn(Schedulers.io())

--- a/app/src/main/java/com/github/mag0716/memorytraining/receiver/BootCompletedReceiver.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/receiver/BootCompletedReceiver.java
@@ -1,0 +1,33 @@
+package com.github.mag0716.memorytraining.receiver;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+import com.github.mag0716.memorytraining.Application;
+import com.github.mag0716.memorytraining.service.TaskConductor;
+
+import timber.log.Timber;
+
+/**
+ * 端末起動を検知する BroadcastReceiver
+ * <p>
+ * タスクの再登録
+ * Notification の通知
+ * <p>
+ * を実行する
+ * <p>
+ * Created by mag0716 on 2017/07/02.
+ */
+public class BootCompletedReceiver extends BroadcastReceiver {
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        final String action = intent.getAction();
+        Timber.d("BootCompletedReceiver#onReceive : action = %s", action);
+        if (Intent.ACTION_BOOT_COMPLETED.equals(action)) {
+            TaskConductor.registerTaskIfNeeded(context,
+                    ((Application) context.getApplicationContext()).getDatabase().memoryDao());
+            // TODO: 訓練日時が過ぎていたら、Notification を通知する
+        }
+    }
+}

--- a/app/src/main/java/com/github/mag0716/memorytraining/service/TaskConductor.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/service/TaskConductor.java
@@ -16,11 +16,11 @@ import timber.log.Timber;
  * <p>
  * Created by mag0716 on 2017/06/28.
  */
-public class TaskRegister {
+public class TaskConductor {
 
     private static final String TASK_TAG = "MemoryTask";
 
-    private TaskRegister() {
+    private TaskConductor() {
     }
 
     /**

--- a/app/src/main/java/com/github/mag0716/memorytraining/service/TaskConductor.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/service/TaskConductor.java
@@ -84,6 +84,7 @@ public class TaskConductor {
                         TimeUnit.MILLISECONDS.toSeconds(delayMilliseconds) + 60L) // TODO: 固定値の調整
                 .setRequiredNetwork(Task.NETWORK_STATE_ANY)
                 .setRequiresCharging(false)
+                .setPersisted(false)
                 .build();
         manager.schedule(task);
     }

--- a/app/src/main/java/com/github/mag0716/memorytraining/service/TaskConductor.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/service/TaskConductor.java
@@ -5,8 +5,8 @@ import android.support.annotation.NonNull;
 
 import com.github.mag0716.memorytraining.model.Memory;
 import com.github.mag0716.memorytraining.repository.database.MemoryDao;
+import com.github.mag0716.memorytraining.service.gcmnetworkmanager.GcmNetworkManagerService;
 import com.google.android.gms.gcm.GcmNetworkManager;
-import com.google.android.gms.gcm.GcmTaskService;
 import com.google.android.gms.gcm.OneoffTask;
 
 import io.reactivex.Maybe;
@@ -75,7 +75,7 @@ public class TaskConductor {
         final long delay = memory.getNextTrainingDatetime() - System.currentTimeMillis();
         final GcmNetworkManager manager = GcmNetworkManager.getInstance(context);
         final OneoffTask task = new OneoffTask.Builder()
-                .setService(GcmTaskService.class)
+                .setService(GcmNetworkManagerService.class)
                 .setTag(TASK_TAG)
                 .setExecutionWindow(delay, delay + 3600L) // TODO: 固定値の調整
                 .build();

--- a/app/src/main/java/com/github/mag0716/memorytraining/service/TaskConductor.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/service/TaskConductor.java
@@ -26,9 +26,6 @@ public class TaskConductor {
 
     private static final String TASK_TAG = "MemoryTask";
 
-    private TaskConductor() {
-    }
-
     /**
      * 直近の訓練日時のデータがあればタスクを登録する
      *

--- a/app/src/main/java/com/github/mag0716/memorytraining/service/TaskConductor.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/service/TaskConductor.java
@@ -85,6 +85,7 @@ public class TaskConductor {
                 .setRequiredNetwork(Task.NETWORK_STATE_ANY)
                 .setRequiresCharging(false)
                 .setPersisted(false)
+                .setUpdateCurrent(true)
                 .build();
         manager.schedule(task);
     }

--- a/app/src/main/java/com/github/mag0716/memorytraining/service/TaskConductor.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/service/TaskConductor.java
@@ -8,6 +8,9 @@ import com.github.mag0716.memorytraining.repository.database.MemoryDao;
 import com.github.mag0716.memorytraining.service.gcmnetworkmanager.GcmNetworkManagerService;
 import com.google.android.gms.gcm.GcmNetworkManager;
 import com.google.android.gms.gcm.OneoffTask;
+import com.google.android.gms.gcm.Task;
+
+import java.util.concurrent.TimeUnit;
 
 import io.reactivex.Maybe;
 import io.reactivex.MaybeObserver;
@@ -72,12 +75,15 @@ public class TaskConductor {
      */
     private static void registerGcmTask(@NonNull Context context, @NonNull Memory memory) {
         Timber.d("registerGcmTask : memory = %s", memory);
-        final long delay = memory.getNextTrainingDatetime() - System.currentTimeMillis();
+        final long delayMilliseconds = memory.getNextTrainingDatetime() - System.currentTimeMillis();
         final GcmNetworkManager manager = GcmNetworkManager.getInstance(context);
         final OneoffTask task = new OneoffTask.Builder()
                 .setService(GcmNetworkManagerService.class)
                 .setTag(TASK_TAG)
-                .setExecutionWindow(delay, delay + 3600L) // TODO: 固定値の調整
+                .setExecutionWindow(TimeUnit.MILLISECONDS.toSeconds(delayMilliseconds),
+                        TimeUnit.MILLISECONDS.toSeconds(delayMilliseconds) + 60L) // TODO: 固定値の調整
+                .setRequiredNetwork(Task.NETWORK_STATE_ANY)
+                .setRequiresCharging(false)
                 .build();
         manager.schedule(task);
     }

--- a/app/src/main/java/com/github/mag0716/memorytraining/service/TaskRegister.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/service/TaskRegister.java
@@ -1,0 +1,53 @@
+package com.github.mag0716.memorytraining.service;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+
+import com.github.mag0716.memorytraining.model.Memory;
+import com.github.mag0716.memorytraining.repository.database.MemoryDao;
+import com.google.android.gms.gcm.GcmNetworkManager;
+import com.google.android.gms.gcm.GcmTaskService;
+import com.google.android.gms.gcm.OneoffTask;
+
+import timber.log.Timber;
+
+/**
+ * 定期実行タスクの登録を管理して、どの API を利用して登録するのかを振り分ける
+ * <p>
+ * Created by mag0716 on 2017/06/28.
+ */
+public class TaskRegister {
+
+    private static final String TASK_TAG = "MemoryTask";
+
+    private TaskRegister() {
+    }
+
+    /**
+     * 直近の訓練日時のデータがあればタスクを登録する
+     *
+     * @param dao MemoryDao
+     */
+    public static void registerTaskIfNeeded(@NonNull Context context, @NonNull MemoryDao dao) {
+        // TODO: 各 API の振り分け, タスクの登録, 選択中の API 以外のタスクをキャンセル
+//        final Memory recentMemory;
+//        registerGcmTask(context, recentMemory);
+    }
+
+    /**
+     * GcmNetworkManager を利用してタスクを登録する
+     *
+     * @param memory 直近の訓練データ
+     */
+    private static void registerGcmTask(@NonNull Context context, @NonNull Memory memory) {
+        Timber.d("registerGcmTask : memory = %s", memory);
+        final long delay = memory.getNextTrainingDatetime() - System.currentTimeMillis();
+        final GcmNetworkManager manager = GcmNetworkManager.getInstance(context);
+        final OneoffTask task = new OneoffTask.Builder()
+                .setService(GcmTaskService.class)
+                .setTag(TASK_TAG)
+                .setExecutionWindow(delay, delay + 3600L) // TODO: 固定値の調整
+                .build();
+        manager.schedule(task);
+    }
+}

--- a/app/src/main/java/com/github/mag0716/memorytraining/service/gcmnetworkmanager/GcmNetworkManagerService.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/service/gcmnetworkmanager/GcmNetworkManagerService.java
@@ -1,0 +1,27 @@
+package com.github.mag0716.memorytraining.service.gcmnetworkmanager;
+
+import com.google.android.gms.gcm.GcmNetworkManager;
+import com.google.android.gms.gcm.GcmTaskService;
+import com.google.android.gms.gcm.TaskParams;
+
+import timber.log.Timber;
+
+/**
+ * Created by mag0716 on 2017/06/27.
+ */
+public class GcmNetworkManagerService extends GcmTaskService {
+
+    @Override
+    public int onRunTask(TaskParams taskParams) {
+        Timber.d("onRunTask : tag = %s", taskParams.getTag());
+        // TODO: 現在日時を超えたデータがあれば BroadcastReceiver に通知を投げる
+        return GcmNetworkManager.RESULT_SUCCESS;
+    }
+
+    @Override
+    public void onInitializeTasks() {
+        super.onInitializeTasks();
+        Timber.d("onInitializeTasks");
+        // TODO: Play Services, アプリのアップデートでタスクがクリアされるので、再セットする
+    }
+}

--- a/app/src/main/java/com/github/mag0716/memorytraining/util/DatetimeUtil.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/util/DatetimeUtil.java
@@ -1,0 +1,25 @@
+package com.github.mag0716.memorytraining.util;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+/**
+ * Created by mag0716 on 2017/07/02.
+ */
+public final class DatetimeUtil {
+
+    private DatetimeUtil() {
+    }
+
+    /**
+     * デバッグで確認しやすいフォーマットに変換
+     *
+     * @param datetime 日時
+     * @return yyyy/MM/dd HH:mm:ss フォーマットの文字列
+     */
+    public static String convertDebugFormat(long datetime) {
+        final SimpleDateFormat debugFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss", Locale.getDefault());
+        return debugFormat.format(new Date(datetime));
+    }
+}


### PR DESCRIPTION
## Description

GcmNetworkManager を使った定期実行処理を実装
Memory#nextTrainingDatetime の日時になったら定期実行処理を呼び出すように実装する。

## TODO

- [x] GcmNetworkManager 調査
- [x] 直近の訓練データの取得
- [x] タスクの登録
    - [x] onInitializeTasks
    - [x] 訓練データの追加時
    - [x] タスク実行時

## 動作確認

- [x] タスクが登録されていること

## Link

* https://developers.google.com/cloud-messaging/network-manager
* https://developers.google.com/android/reference/com/google/android/gms/gcm/GcmNetworkManager