### PR TITLE
inMemory の DB の利用をやめる

### DIFF
--- a/app/src/debug/java/com/github/mag0716/memorytraining/DebugApplication.java
+++ b/app/src/debug/java/com/github/mag0716/memorytraining/DebugApplication.java
@@ -1,13 +1,11 @@
 package com.github.mag0716.memorytraining;
 
-import android.arch.persistence.room.Room;
 import android.content.Context;
 import android.support.annotation.NonNull;
 
 import com.annimon.stream.Stream;
 import com.facebook.stetho.Stetho;
 import com.github.mag0716.memorytraining.model.Memory;
-import com.github.mag0716.memorytraining.repository.database.ApplicationDatabase;
 import com.github.mag0716.memorytraining.repository.database.MemoryDao;
 import com.github.mag0716.memorytraining.service.TaskConductor;
 import com.squareup.moshi.JsonAdapter;
@@ -46,7 +44,7 @@ public class DebugApplication extends Application {
             throw new IllegalStateException("Database initialized already.");
         }
 
-        database = Room.inMemoryDatabaseBuilder(context, ApplicationDatabase.class).build();
+        database = getDatabase();
 
         // TODO: repository 経由でのアクセスに変更し、DB アクセスを隠蔽する
         // insert debug data

--- a/app/src/debug/java/com/github/mag0716/memorytraining/DebugApplication.java
+++ b/app/src/debug/java/com/github/mag0716/memorytraining/DebugApplication.java
@@ -59,7 +59,7 @@ public class DebugApplication extends Application {
                 })
                 .subscribeOn(Schedulers.io())
                 .subscribe(() -> Timber.d("completed to insert debug data."),
-                        throwable -> Timber.w("failed to insert debug data.", throwable));
+                        throwable -> Timber.w(throwable, "failed to insert debug data."));
     }
 
     private List<Memory> loadTestData() {


### PR DESCRIPTION
## Description

追加、更新などの動作を一通り確認できたのと、
毎回クリアされると定期実行の確認が不便になってきたので inMemory の DB の利用をやめる。

## Link

## TODO

- [x] Application#getDatabase で生成する DB を利用する

## Check List

- [x] デバッグ用のデータが保存されること
- [x] アプリのプロセス停止後に再起動してもデータが保持されていること
