### PR TITLE
ボタンのカスタムテーマ定義

### DIFF
--- a/app/src/main/res/color/button_color.xml
+++ b/app/src/main/res/color/button_color.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/buttons_raised_disabled" android:state_enabled="false" />
+    <item android:color="@color/primary_dark" />
+</selector>

--- a/app/src/main/res/color/button_text_color.xml
+++ b/app/src/main/res/color/button_text_color.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/buttons_raised_disabled_text" android:state_enabled="false" />
+    <item android:color="@color/primary_light_text" />
+</selector>

--- a/app/src/main/res/layout/fragment_edit.xml
+++ b/app/src/main/res/layout/fragment_edit.xml
@@ -67,6 +67,7 @@
             android:enabled="@{viewModel.valid}"
             android:onClick="@{() -> presenter.save(viewModel.memory)}"
             android:text="@string/edit_save_button_name"
+            android:theme="@style/AppTheme.Button"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintHorizontal_bias="1"
             app:layout_constraintLeft_toLeftOf="parent"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,6 +7,7 @@
 
     <!-- text -->
     <color name="primary_text">#DE000000</color>
+    <color name="primary_light_text">#FFFFFF</color>
     <color name="secondary_text">#8A000000</color>
     <color name="disable_text">#39000000</color>
     <color name="hint_text">#39000000</color>

--- a/app/src/main/res/values/colors_material.xml
+++ b/app/src/main/res/values/colors_material.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Buttons(https://material.io/guidelines/components/buttons.html) -->
+    <color name="buttons_raised_disabled_text">#42000000</color>
+    <color name="buttons_raised_disabled">#1F000000</color>
+    <color name="buttons_dark_raised_disabled_text">#4DFFFFFF</color>
+    <color name="buttons_dark_raised_disabled">#1FFFFFFF</color>
+
+</resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -19,6 +19,11 @@
 
     <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
 
+    <style name="AppTheme.Button" parent="Widget.AppCompat.Button">
+        <item name="colorButtonNormal">@color/primary_dark</item>
+        <item name="android:textColor">@color/primary_light_text</item>
+    </style>
+
     <style name="AppTheme.Card" parent="CardView.Light" />
 
     <style name="AppTheme.Card.Title">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -19,9 +19,9 @@
 
     <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
 
-    <style name="AppTheme.Button" parent="Widget.AppCompat.Button">
-        <item name="colorButtonNormal">@color/primary_dark</item>
-        <item name="android:textColor">@color/primary_light_text</item>
+    <style name="AppTheme.Button" parent="Widget.AppCompat.Button.Colored">
+        <item name="colorButtonNormal">@color/button_color</item>
+        <item name="android:textColor">@color/button_text_color</item>
     </style>
 
     <style name="AppTheme.Card" parent="CardView.Light" />


### PR DESCRIPTION
## Description

追加、編集画面の保存ボタンのテーマをカスタムする

## Link

#32 

## Reference

* https://stackoverflow.com/questions/29860906/widget-appcompat-button-colorbuttonnormal-shows-gray
* http://y-anz-m.blogspot.jp/2015/09/appcompat-raised-button.html

## TODO

- [x] カスタムテーマ定義
- [x] EditFragment のボタンにテーマを適用

## Check List

- [x] 通常
- [x] 非活性
- [x] タップ
- [ ] フォーカス