### PR TITLE
Activity 復帰で不正な表示

### DIFF
--- a/app/src/main/java/com/github/mag0716/memorytraining/activity/TrainingActivity.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/activity/TrainingActivity.java
@@ -11,7 +11,6 @@ import android.support.v4.app.FragmentTransaction;
 import android.support.v7.app.AppCompatActivity;
 import android.view.Menu;
 import android.view.MenuItem;
-import android.view.View;
 
 import com.github.mag0716.memorytraining.R;
 import com.github.mag0716.memorytraining.databinding.ActivityTrainingBinding;
@@ -19,6 +18,7 @@ import com.github.mag0716.memorytraining.fragment.EditFragment;
 import com.github.mag0716.memorytraining.fragment.ListFragment;
 import com.github.mag0716.memorytraining.presenter.TrainingPresenter;
 import com.github.mag0716.memorytraining.view.TrainingView;
+import com.github.mag0716.memorytraining.viewmodel.TrainingViewModel;
 
 import timber.log.Timber;
 
@@ -30,6 +30,7 @@ public class TrainingActivity extends AppCompatActivity implements TrainingView,
     private ActivityTrainingBinding binding;
     private TrainingPresenter presenter;
     private FragmentManager fragmentManager;
+    private TrainingViewModel viewModel = new TrainingViewModel();
 
     public static Intent createIntent(@NonNull Context context) {
         return new Intent(context, TrainingActivity.class);
@@ -43,6 +44,7 @@ public class TrainingActivity extends AppCompatActivity implements TrainingView,
         binding = DataBindingUtil.setContentView(this, R.layout.activity_training);
         presenter = new TrainingPresenter();
         fragmentManager = getSupportFragmentManager();
+        binding.setViewModel(viewModel);
         binding.setPresenter(presenter);
         setSupportActionBar(binding.toolbar);
 
@@ -146,10 +148,6 @@ public class TrainingActivity extends AppCompatActivity implements TrainingView,
     private void updateFabVisibility() {
         final Fragment currentFragment = fragmentManager.findFragmentById(R.id.content);
         Timber.d("updateFabVisibility : %s", currentFragment);
-        if (currentFragment instanceof ListFragment) {
-            binding.fab.setVisibility(View.VISIBLE);
-        } else {
-            binding.fab.setVisibility(View.INVISIBLE);
-        }
+        viewModel.setAddable(currentFragment instanceof ListFragment);
     }
 }

--- a/app/src/main/java/com/github/mag0716/memorytraining/activity/TrainingActivity.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/activity/TrainingActivity.java
@@ -20,6 +20,8 @@ import com.github.mag0716.memorytraining.fragment.ListFragment;
 import com.github.mag0716.memorytraining.presenter.TrainingPresenter;
 import com.github.mag0716.memorytraining.view.TrainingView;
 
+import timber.log.Timber;
+
 /**
  * 訓練画面
  */
@@ -97,15 +99,8 @@ public class TrainingActivity extends AppCompatActivity implements TrainingView,
 
     @Override
     public void onBackStackChanged() {
-        final Fragment currentFragment = fragmentManager.findFragmentById(R.id.content);
-        // TODO: ここにロジックがあるのが若干気持ち悪い
-        if (currentFragment instanceof ListFragment) {
-            binding.fab.setVisibility(View.VISIBLE);
-        } else {
-            binding.fab.setVisibility(View.INVISIBLE);
-        }
+        updateFabVisibility();
     }
-
 
     // region TrainingView
 
@@ -117,13 +112,17 @@ public class TrainingActivity extends AppCompatActivity implements TrainingView,
 
     @Override
     public void showTrainingList() {
+        Timber.d("showTrainingList : %s", fragmentManager.findFragmentByTag(ListFragment.TAG));
         if (fragmentManager.findFragmentByTag(ListFragment.TAG) == null) {
             fragmentManager.beginTransaction().replace(R.id.content, ListFragment.newInstance(), ListFragment.TAG).commit();
+        } else {
+            updateFabVisibility();
         }
     }
 
     @Override
     public void showAddView() {
+        Timber.d("showAddView");
         final FragmentTransaction transaction = fragmentManager.beginTransaction();
         transaction.addToBackStack(EditFragment.TAG);
         transaction.replace(R.id.content, EditFragment.newInstance(), EditFragment.TAG);
@@ -132,6 +131,7 @@ public class TrainingActivity extends AppCompatActivity implements TrainingView,
 
     @Override
     public void showEditView(long id) {
+        Timber.d("showEditView : %d", id);
         final FragmentTransaction transaction = fragmentManager.beginTransaction();
         transaction.addToBackStack(EditFragment.TAG);
         transaction.replace(R.id.content, EditFragment.newInstance(id), EditFragment.TAG);
@@ -139,4 +139,17 @@ public class TrainingActivity extends AppCompatActivity implements TrainingView,
     }
 
     // endregion
+
+    /**
+     * FAB の表示状態を更新する
+     */
+    private void updateFabVisibility() {
+        final Fragment currentFragment = fragmentManager.findFragmentById(R.id.content);
+        Timber.d("updateFabVisibility : %s", currentFragment);
+        if (currentFragment instanceof ListFragment) {
+            binding.fab.setVisibility(View.VISIBLE);
+        } else {
+            binding.fab.setVisibility(View.INVISIBLE);
+        }
+    }
 }

--- a/app/src/main/java/com/github/mag0716/memorytraining/fragment/EditFragment.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/fragment/EditFragment.java
@@ -28,10 +28,13 @@ public class EditFragment extends Fragment implements EditView {
 
     public static final String TAG = EditFragment.class.getCanonicalName();
     private static final String EXTRA_MEMORY_ID = TAG + ".MEMORY_ID";
+    private static final String EXTRA_MEMORY = TAG + ".MEMORY";
 
     private FragmentEditBinding binding;
     private EditViewModel viewModel;
     private EditPresenter presenter;
+
+    private Memory memory;
 
     /**
      * インスタンスを返却
@@ -67,6 +70,12 @@ public class EditFragment extends Fragment implements EditView {
         binding = DataBindingUtil.inflate(inflater, R.layout.fragment_edit, container, false);
         presenter = new EditPresenter(((Application) getContext().getApplicationContext()).getDatabase().memoryDao());
         binding.setPresenter(presenter);
+        if (savedInstanceState != null) {
+            memory = savedInstanceState.getParcelable(EXTRA_MEMORY);
+            if (memory != null) {
+                showMemory(memory);
+            }
+        }
         return binding.getRoot();
     }
 
@@ -74,7 +83,9 @@ public class EditFragment extends Fragment implements EditView {
     public void onResume() {
         super.onResume();
         presenter.attachView(this);
-        presenter.loadIfNeeded(getArguments(), EXTRA_MEMORY_ID);
+        if (memory == null) {
+            presenter.loadIfNeeded(getArguments(), EXTRA_MEMORY_ID);
+        }
     }
 
     @Override
@@ -83,12 +94,20 @@ public class EditFragment extends Fragment implements EditView {
         presenter.detachView();
     }
 
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putParcelable(EXTRA_MEMORY, viewModel.getMemory());
+    }
+
     // endregion
 
     // region EditView
 
     @Override
     public void showMemory(@NonNull Memory memory) {
+        Timber.d("showMemory : %s", memory);
+        this.memory = memory;
         viewModel = new EditViewModel(memory);
         binding.setViewModel(viewModel);
     }

--- a/app/src/main/java/com/github/mag0716/memorytraining/viewmodel/TrainingViewModel.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/viewmodel/TrainingViewModel.java
@@ -1,0 +1,27 @@
+package com.github.mag0716.memorytraining.viewmodel;
+
+import android.databinding.BaseObservable;
+import android.databinding.Bindable;
+
+import com.github.mag0716.memorytraining.BR;
+
+/**
+ * Created by mag0716 on 2017/07/20.
+ */
+public class TrainingViewModel extends BaseObservable {
+
+    /**
+     * 訓練データを追加可能かどうか
+     */
+    private boolean addable = true;
+
+    @Bindable
+    public boolean isAddable() {
+        return addable;
+    }
+
+    public void setAddable(boolean addable) {
+        this.addable = addable;
+        notifyPropertyChanged(BR.addable);
+    }
+}

--- a/app/src/main/res/layout/activity_training.xml
+++ b/app/src/main/res/layout/activity_training.xml
@@ -6,6 +6,10 @@
     <data>
 
         <variable
+            name="viewModel"
+            type="com.github.mag0716.memorytraining.viewmodel.TrainingViewModel" />
+
+        <variable
             name="presenter"
             type="com.github.mag0716.memorytraining.presenter.TrainingPresenter" />
     </data>
@@ -43,7 +47,8 @@
             android:layout_margin="@dimen/fab_margin"
             android:onClick="@{() -> presenter.addMemory()}"
             app:layout_behavior="com.github.mag0716.memorytraining.view.behavior.FloatingActionButtonShowHideBehavior"
-            app:srcCompat="@drawable/ic_add_white_24dp" />
+            app:srcCompat="@drawable/ic_add_white_24dp"
+            app:visibleOrInvisible="@{viewModel.isAddable}" />
 
     </android.support.design.widget.CoordinatorLayout>
 </layout>


### PR DESCRIPTION
## Description

編集画面で、BG -> FG した時に、Activity が再生成されると、
入力していたデータは消え、FAB が表示されている

![device-2017-07-19-233806](https://user-images.githubusercontent.com/1555252/28372790-9605d954-6cdb-11e7-977c-b3fc9bfcb1a8.png)

## Link

#38

## Cause

### EditFragment

Activity の再生成で、Arguments から ID を取得し、DB から取得したデータを展開している。
Memory を保存、復帰して、すでに Memory が存在していたら、そちらを利用するようにする必要がある。

### FAB

```
07-20 23:14:48.987 4338-4338/com.github.mag0716.memorytraining D/TrainingActivity: showTrainingList : ListFragment{2ef87d4 #0 id=0x7f08002e com.github.mag0716.memorytraining.fragment.ListFragment}
```

FAB の初期表示状態は Visible
Activity の再生成で、OS が Fragment を再生するが、FAB の表示状態を変更していない。

## TODO

- [x] FAB
- [x] EditFragment

## Check List

- [x] 一覧画面で FAB が表示状態であること
- [x] 追加／編集画面で FAB が非表示状態であること
- [x] 追加／編集画面で BG -> FG して、FAB が非表示状態であること
- [x] 編集画面遷移時に選択したデータが反映されること
- [x] 追加／編集画面で BG -> FG して、入力中のデータが復帰すること