### PR TITLE
Android Studio 3.0 Canary7 にアップデート

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-alpha5'
+        classpath 'com.android.tools.build:gradle:3.0.0-alpha7'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
## Description

Android Studio 3.0 Canary7 にアップデート

## Link

* https://androidstudio.googleblog.com/2017/07/android-studio-30-canary-7-is-now.html

## TODO

- [x] com.android.tools.build:gradle:3.0.0-alpha7 に更新

## Check List

- [x] ビルドできること
- [x] 単体テストが通ること