### PR TITLE
Android Studio 3.0 Canary8 にアップデート

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.1.3'
+    ext.kotlin_version = '1.1.3-2'
 
     repositories {
         jcenter()
@@ -11,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-alpha7'
+        classpath 'com.android.tools.build:gradle:3.0.0-alpha8'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
## Description

Android Studio を最新の 3.0 Canary8 にアップデート

## Link

* https://androidstudio.googleblog.com/2017/07/android-studio-30-canary-8-is-now.html

## TODO

- [x] build.gradle 修正

## Check List

- [x] ビルドが通ること
- [x] テストが通ること