### PR TITLE
一覧画面で登録してあるデータを全て表示する

### DIFF
--- a/app/src/main/java/com/github/mag0716/memorytraining/activity/TrainingActivity.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/activity/TrainingActivity.java
@@ -5,9 +5,13 @@ import android.content.Intent;
 import android.databinding.DataBindingUtil;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.design.widget.NavigationView;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
+import android.support.v4.view.GravityCompat;
+import android.support.v4.widget.DrawerLayout;
+import android.support.v7.app.ActionBarDrawerToggle;
 import android.support.v7.app.AppCompatActivity;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -25,7 +29,8 @@ import timber.log.Timber;
 /**
  * 訓練画面
  */
-public class TrainingActivity extends AppCompatActivity implements TrainingView, FragmentManager.OnBackStackChangedListener {
+public class TrainingActivity extends AppCompatActivity
+        implements TrainingView, FragmentManager.OnBackStackChangedListener, NavigationView.OnNavigationItemSelectedListener {
 
     private ActivityTrainingBinding binding;
     private TrainingPresenter presenter;
@@ -47,6 +52,15 @@ public class TrainingActivity extends AppCompatActivity implements TrainingView,
         binding.setViewModel(viewModel);
         binding.setPresenter(presenter);
         setSupportActionBar(binding.toolbar);
+
+        DrawerLayout drawer = (DrawerLayout) findViewById(R.id.drawer_layout);
+        ActionBarDrawerToggle toggle = new ActionBarDrawerToggle(
+                this, drawer, binding.toolbar, R.string.navigation_drawer_open, R.string.navigation_drawer_close);
+        drawer.addDrawerListener(toggle);
+        toggle.syncState();
+
+        NavigationView navigationView = (NavigationView) findViewById(R.id.navigation_view);
+        navigationView.setNavigationItemSelectedListener(this);
 
         showTrainingList();
     }
@@ -91,11 +105,15 @@ public class TrainingActivity extends AppCompatActivity implements TrainingView,
 
     @Override
     public void onBackPressed() {
-        final FragmentManager manager = getSupportFragmentManager();
-        if (manager.getBackStackEntryCount() > 0) {
-            manager.popBackStack();
+        if (binding.drawerLayout.isDrawerOpen(GravityCompat.START)) {
+            binding.drawerLayout.closeDrawer(GravityCompat.START);
         } else {
-            super.onBackPressed();
+            final FragmentManager manager = getSupportFragmentManager();
+            if (manager.getBackStackEntryCount() > 0) {
+                manager.popBackStack();
+            } else {
+                super.onBackPressed();
+            }
         }
     }
 
@@ -103,6 +121,17 @@ public class TrainingActivity extends AppCompatActivity implements TrainingView,
     public void onBackStackChanged() {
         updateFabVisibility();
     }
+
+    // region NavigationView.OnNavigationItemSelectedListener
+
+    @Override
+    public boolean onNavigationItemSelected(@NonNull MenuItem menuItem) {
+        // TODO:
+        binding.drawerLayout.closeDrawer(GravityCompat.START);
+        return true;
+    }
+
+    // endregion
 
     // region TrainingView
 

--- a/app/src/main/java/com/github/mag0716/memorytraining/activity/TrainingActivity.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/activity/TrainingActivity.java
@@ -80,7 +80,11 @@ public class TrainingActivity extends AppCompatActivity
         NavigationView navigationView = (NavigationView) findViewById(R.id.navigation_view);
         navigationView.setNavigationItemSelectedListener(this);
 
-        showTrainingList();
+        if (savedInstanceState == null) {
+            showTrainingList(viewModel.getCurrentCategory());
+        } else {
+            updateView();
+        }
     }
 
     @Override
@@ -166,13 +170,10 @@ public class TrainingActivity extends AppCompatActivity
     }
 
     @Override
-    public void showTrainingList() {
-        Timber.d("showTrainingList : %s", fragmentManager.findFragmentByTag(ListFragment.TAG));
-        if (fragmentManager.findFragmentByTag(ListFragment.TAG) == null) {
-            fragmentManager.beginTransaction().replace(R.id.content, ListFragment.newInstance(), ListFragment.TAG).commit();
-        } else {
-            updateView();
-        }
+    public void showTrainingList(int category) {
+        final ListFragment fragment = (ListFragment) fragmentManager.findFragmentByTag(ListFragment.TAG);
+        Timber.d("showTrainingList : %d, %s", category, fragment);
+        fragmentManager.beginTransaction().replace(R.id.content, ListFragment.newInstance(category), ListFragment.TAG).commit();
     }
 
     @Override

--- a/app/src/main/java/com/github/mag0716/memorytraining/activity/TrainingActivity.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/activity/TrainingActivity.java
@@ -45,8 +45,11 @@ public class TrainingActivity extends AppCompatActivity
     private final Observable.OnPropertyChangedCallback propertyChangedCallback = new OnPropertyChangedCallback() {
         @Override
         public void onPropertyChanged(Observable sender, int propertyId) {
+            Timber.d("onPropertyChanged : %d", propertyId);
             if (propertyId == BR.selectableCategory) {
                 setDrawerEnabled(viewModel.isSelectableCategory());
+            } else if (propertyId == BR.currentCategory) {
+                presenter.changeCategory(viewModel.getCurrentCategory());
             }
         }
     };
@@ -147,7 +150,7 @@ public class TrainingActivity extends AppCompatActivity
 
     @Override
     public boolean onNavigationItemSelected(@NonNull MenuItem menuItem) {
-        // TODO:
+        viewModel.changeCategory(menuItem.getItemId());
         binding.drawerLayout.closeDrawer(GravityCompat.START);
         return true;
     }

--- a/app/src/main/java/com/github/mag0716/memorytraining/activity/TrainingActivity.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/activity/TrainingActivity.java
@@ -15,15 +15,18 @@ import android.support.v4.view.GravityCompat;
 import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.ActionBarDrawerToggle;
 import android.support.v7.app.AppCompatActivity;
+import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
 
 import com.github.mag0716.memorytraining.BR;
 import com.github.mag0716.memorytraining.R;
 import com.github.mag0716.memorytraining.databinding.ActivityTrainingBinding;
+import com.github.mag0716.memorytraining.databinding.DrawerHeaderBinding;
 import com.github.mag0716.memorytraining.fragment.EditFragment;
 import com.github.mag0716.memorytraining.fragment.ListFragment;
 import com.github.mag0716.memorytraining.presenter.TrainingPresenter;
+import com.github.mag0716.memorytraining.util.DeviceUtil;
 import com.github.mag0716.memorytraining.view.TrainingView;
 import com.github.mag0716.memorytraining.viewmodel.TrainingViewModel;
 
@@ -36,6 +39,7 @@ public class TrainingActivity extends AppCompatActivity
         implements TrainingView, FragmentManager.OnBackStackChangedListener, NavigationView.OnNavigationItemSelectedListener {
 
     private ActivityTrainingBinding binding;
+    private DrawerHeaderBinding drawerHeaderBinding;
     private TrainingPresenter presenter;
     private FragmentManager fragmentManager;
     private TrainingViewModel viewModel = new TrainingViewModel();
@@ -64,6 +68,9 @@ public class TrainingActivity extends AppCompatActivity
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         binding = DataBindingUtil.setContentView(this, R.layout.activity_training);
+        drawerHeaderBinding = DataBindingUtil.inflate(LayoutInflater.from(this), R.layout.drawer_header, binding.drawerLayout, false);
+        drawerHeaderBinding.setViewModel(viewModel);
+        binding.navigationView.addHeaderView(drawerHeaderBinding.getRoot());
         viewModel.addOnPropertyChangedCallback(propertyChangedCallback);
         presenter = new TrainingPresenter();
         fragmentManager = getSupportFragmentManager();
@@ -85,6 +92,12 @@ public class TrainingActivity extends AppCompatActivity
         } else {
             updateView();
         }
+    }
+
+    @Override
+    public void onWindowFocusChanged(boolean hasFocus) {
+        super.onWindowFocusChanged(hasFocus);
+        viewModel.calculateDrawerHeaderHeight(this, DeviceUtil.getStatusBarHeight(getWindow()));
     }
 
     @Override

--- a/app/src/main/java/com/github/mag0716/memorytraining/fragment/ListFragment.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/fragment/ListFragment.java
@@ -61,12 +61,15 @@ public class ListFragment extends Fragment implements ListView {
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-
+        final Bundle bundle = getArguments();
+        if (bundle != null) {
+            category = bundle.getInt(EXTRA_CATEGORY);
+        }
         binding = DataBindingUtil.inflate(inflater, R.layout.fragment_list, container, false);
         binding.setViewModel(viewModel);
         presenter = new ListPresenter(((Application) getContext().getApplicationContext()).getDatabase().memoryDao());
         binding.setPresenter(presenter);
-        adapter = new MemoryListAdapter(getContext(), presenter);
+        adapter = new MemoryListAdapter(getContext(), presenter, category);
         binding.trainingList.setLayoutManager(new LinearLayoutManager(getContext()));
         itemDecoration = new CardItemDecoration(getContext());
         binding.trainingList.addItemDecoration(itemDecoration);
@@ -77,10 +80,6 @@ public class ListFragment extends Fragment implements ListView {
     @Override
     public void onResume() {
         super.onResume();
-        final Bundle bundle = getArguments();
-        if (bundle != null) {
-            category = bundle.getInt(EXTRA_CATEGORY);
-        }
         Timber.d("onResume : %d", category);
         presenter.attachView(this);
         presenter.loadTrainingData(category, System.currentTimeMillis());

--- a/app/src/main/java/com/github/mag0716/memorytraining/fragment/ListFragment.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/fragment/ListFragment.java
@@ -24,6 +24,8 @@ import com.github.mag0716.memorytraining.viewmodel.ListViewModel;
 
 import java.util.List;
 
+import timber.log.Timber;
+
 /**
  * 訓練データ一覧画面
  * <p>
@@ -32,6 +34,7 @@ import java.util.List;
 public class ListFragment extends Fragment implements ListView {
 
     public static final String TAG = ListFragment.class.getCanonicalName();
+    private static final String EXTRA_CATEGORY = TAG + ".CATEGORY";
 
     private FragmentListBinding binding;
     private final ListViewModel viewModel = new ListViewModel();
@@ -40,8 +43,14 @@ public class ListFragment extends Fragment implements ListView {
     private MemoryListAdapter adapter;
     private RecyclerView.ItemDecoration itemDecoration;
 
-    public static ListFragment newInstance() {
-        return new ListFragment();
+    private int category;
+
+    public static ListFragment newInstance(int category) {
+        ListFragment fragment = new ListFragment();
+        final Bundle bundle = new Bundle();
+        bundle.putInt(EXTRA_CATEGORY, category);
+        fragment.setArguments(bundle);
+        return fragment;
     }
 
     public ListFragment() {
@@ -52,6 +61,7 @@ public class ListFragment extends Fragment implements ListView {
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+
         binding = DataBindingUtil.inflate(inflater, R.layout.fragment_list, container, false);
         binding.setViewModel(viewModel);
         presenter = new ListPresenter(((Application) getContext().getApplicationContext()).getDatabase().memoryDao());
@@ -67,7 +77,13 @@ public class ListFragment extends Fragment implements ListView {
     @Override
     public void onResume() {
         super.onResume();
+        final Bundle bundle = getArguments();
+        if (bundle != null) {
+            category = bundle.getInt(EXTRA_CATEGORY);
+        }
+        Timber.d("onResume : %d", category);
         presenter.attachView(this);
+        // TODO: カテゴリを指定する
         presenter.loadTrainingData(System.currentTimeMillis());
     }
 

--- a/app/src/main/java/com/github/mag0716/memorytraining/fragment/ListFragment.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/fragment/ListFragment.java
@@ -83,8 +83,7 @@ public class ListFragment extends Fragment implements ListView {
         }
         Timber.d("onResume : %d", category);
         presenter.attachView(this);
-        // TODO: カテゴリを指定する
-        presenter.loadTrainingData(System.currentTimeMillis());
+        presenter.loadTrainingData(category, System.currentTimeMillis());
     }
 
     @Override

--- a/app/src/main/java/com/github/mag0716/memorytraining/presenter/ListPresenter.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/presenter/ListPresenter.java
@@ -8,7 +8,9 @@ import com.github.mag0716.memorytraining.repository.database.MemoryDao;
 import com.github.mag0716.memorytraining.service.TaskConductor;
 import com.github.mag0716.memorytraining.view.IView;
 import com.github.mag0716.memorytraining.view.ListView;
+import com.github.mag0716.memorytraining.viewmodel.TrainingViewModel;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import io.reactivex.Single;
@@ -49,11 +51,20 @@ public class ListPresenter implements IPresenter {
     /**
      * 訓練日時が過ぎているデータを取得する
      *
+     * @param category         カテゴリ
      * @param trainingDatetime 訓練日時
      */
-    public void loadTrainingData(long trainingDatetime) {
+    public void loadTrainingData(int category, long trainingDatetime) {
+        Timber.d("loadTrainingData : %d, %d", category, trainingDatetime);
         disposables.add(Single.create((SingleOnSubscribe<List<Memory>>) emitter -> {
-            final List<Memory> memoryList = dao.loadAll(trainingDatetime);
+            final List<Memory> memoryList;
+            if (category == TrainingViewModel.CATEGORY_ALL) {
+                memoryList = dao.loadAll();
+            } else if (category == TrainingViewModel.CATEGORY_ONLY_NEED_TRAINING) {
+                memoryList = dao.loadAll(trainingDatetime);
+            } else {
+                memoryList = new ArrayList<>();
+            }
             emitter.onSuccess(memoryList);
         })
                 .subscribeOn(Schedulers.io())

--- a/app/src/main/java/com/github/mag0716/memorytraining/presenter/TrainingPresenter.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/presenter/TrainingPresenter.java
@@ -36,7 +36,7 @@ public class TrainingPresenter implements IPresenter {
      */
     public void changeCategory(int category) {
         Timber.d("changeCategory : %d", category);
-        // TODO:
+        view.showTrainingList(category);
     }
 
     /**

--- a/app/src/main/java/com/github/mag0716/memorytraining/presenter/TrainingPresenter.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/presenter/TrainingPresenter.java
@@ -30,6 +30,16 @@ public class TrainingPresenter implements IPresenter {
     }
 
     /**
+     * カテゴリの変更
+     *
+     * @param category カテゴリ
+     */
+    public void changeCategory(int category) {
+        Timber.d("changeCategory : %d", category);
+        // TODO:
+    }
+
+    /**
      * 訓練データの追加
      */
     public void addMemory() {

--- a/app/src/main/java/com/github/mag0716/memorytraining/util/BindingUtil.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/util/BindingUtil.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import android.support.v7.util.DiffUtil;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.ImageView;
 
 import com.github.mag0716.memorytraining.view.adapter.MemoryListAdapter;
@@ -41,5 +42,12 @@ public class BindingUtil {
             adapter.setViewModelList(viewModelList);
             diffResult.dispatchUpdatesTo(adapter);
         }
+    }
+
+    @BindingAdapter("android:layout_height")
+    public static void setHeight(@NonNull View view, float height) {
+        ViewGroup.LayoutParams layoutParams = view.getLayoutParams();
+        layoutParams.height = (int) height;
+        view.setLayoutParams(layoutParams);
     }
 }

--- a/app/src/main/java/com/github/mag0716/memorytraining/util/DeviceUtil.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/util/DeviceUtil.java
@@ -1,0 +1,18 @@
+package com.github.mag0716.memorytraining.util;
+
+import android.graphics.Rect;
+import android.support.annotation.NonNull;
+import android.view.Window;
+
+/**
+ * Created by mag0716 on 2017/07/29.
+ */
+
+public class DeviceUtil {
+
+    public static int getStatusBarHeight(@NonNull Window window) {
+        final Rect rect = new Rect();
+        window.getDecorView().getWindowVisibleDisplayFrame(rect);
+        return rect.top;
+    }
+}

--- a/app/src/main/java/com/github/mag0716/memorytraining/view/TrainingView.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/view/TrainingView.java
@@ -9,8 +9,10 @@ public interface TrainingView extends IView {
 
     /**
      * 一覧画面を表示する
+     *
+     * @param category 表示するデータのカテゴリ
      */
-    void showTrainingList();
+    void showTrainingList(int category);
 
     /**
      * 追加画面を表示する

--- a/app/src/main/java/com/github/mag0716/memorytraining/view/adapter/MemoryListAdapter.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/view/adapter/MemoryListAdapter.java
@@ -2,7 +2,6 @@ package com.github.mag0716.memorytraining.view.adapter;
 
 import android.content.Context;
 import android.databinding.DataBindingUtil;
-import android.databinding.ViewDataBinding;
 import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
@@ -11,8 +10,10 @@ import android.view.ViewGroup;
 
 import com.github.mag0716.memorytraining.R;
 import com.github.mag0716.memorytraining.databinding.ViewListItemBinding;
+import com.github.mag0716.memorytraining.databinding.ViewTrainableListItemBinding;
 import com.github.mag0716.memorytraining.presenter.ListPresenter;
 import com.github.mag0716.memorytraining.viewmodel.ListItemViewModel;
+import com.github.mag0716.memorytraining.viewmodel.TrainingViewModel;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,33 +23,63 @@ import lombok.Getter;
 /**
  * Created by mag0716 on 2017/06/13.
  */
-public class MemoryListAdapter extends RecyclerView.Adapter<MemoryListAdapter.MemoryViewHolder> {
+public class MemoryListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
+
+    /**
+     * 登録したデータを確認するためだけのセル
+     */
+    private static final int ONLY_VIEW_TYPE = 0;
+    /**
+     * 訓練可能なセル
+     */
+    private static final int TRAINABLE_VIEW_TYPE = 1;
 
     private final LayoutInflater inflater;
     private final ListPresenter presenter;
+    private final int category;
     private final List<ListItemViewModel> viewModelList = new ArrayList<>();
 
-    public MemoryListAdapter(@NonNull Context context, @NonNull ListPresenter presenter) {
+    public MemoryListAdapter(@NonNull Context context, @NonNull ListPresenter presenter, int category) {
         inflater = LayoutInflater.from(context);
         this.presenter = presenter;
+        this.category = category;
     }
 
     @Override
-    public MemoryViewHolder onCreateViewHolder(ViewGroup viewGroup, int position) {
-        return new MemoryViewHolder(inflater.inflate(R.layout.view_list_item, viewGroup, false));
+    public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup viewGroup, int position) {
+        final int viewType = getItemViewType(position);
+        if (viewType == TRAINABLE_VIEW_TYPE) {
+            return new TrainableMemoryViewHolder(inflater.inflate(R.layout.view_trainable_list_item, viewGroup, false));
+        } else {
+            return new MemoryViewHolder(inflater.inflate(R.layout.view_list_item, viewGroup, false));
+        }
     }
 
     @Override
-    public void onBindViewHolder(MemoryViewHolder viewHolder, int position) {
+    public void onBindViewHolder(RecyclerView.ViewHolder viewHolder, int position) {
         final ListItemViewModel viewModel = viewModelList.get(position);
-        ((ViewListItemBinding) viewHolder.binding).setViewModel(viewModel);
-        ((ViewListItemBinding) viewHolder.binding).setPresenter(presenter);
-        viewHolder.binding.executePendingBindings();
+        if (viewHolder instanceof MemoryViewHolder) {
+            ((MemoryViewHolder) viewHolder).binding.setViewModel(viewModel);
+            ((MemoryViewHolder) viewHolder).binding.executePendingBindings();
+        } else if (viewHolder instanceof TrainableMemoryViewHolder) {
+            ((TrainableMemoryViewHolder) viewHolder).binding.setViewModel(viewModel);
+            ((TrainableMemoryViewHolder) viewHolder).binding.setPresenter(presenter);
+            ((TrainableMemoryViewHolder) viewHolder).binding.executePendingBindings();
+        }
     }
 
     @Override
     public int getItemCount() {
         return viewModelList.size();
+    }
+
+    @Override
+    public int getItemViewType(int position) {
+        if (category == TrainingViewModel.CATEGORY_ALL) {
+            return ONLY_VIEW_TYPE;
+        } else {
+            return TRAINABLE_VIEW_TYPE;
+        }
     }
 
     public List<ListItemViewModel> getViewModelList() {
@@ -61,11 +92,20 @@ public class MemoryListAdapter extends RecyclerView.Adapter<MemoryListAdapter.Me
     }
 
     public class MemoryViewHolder extends RecyclerView.ViewHolder {
-
         @Getter
-        private final ViewDataBinding binding;
+        private final ViewListItemBinding binding;
 
         public MemoryViewHolder(View itemView) {
+            super(itemView);
+            binding = DataBindingUtil.bind(itemView);
+        }
+    }
+
+    public class TrainableMemoryViewHolder extends RecyclerView.ViewHolder {
+        @Getter
+        private final ViewTrainableListItemBinding binding;
+
+        public TrainableMemoryViewHolder(View itemView) {
             super(itemView);
             binding = DataBindingUtil.bind(itemView);
         }

--- a/app/src/main/java/com/github/mag0716/memorytraining/viewmodel/TrainingViewModel.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/viewmodel/TrainingViewModel.java
@@ -1,9 +1,12 @@
 package com.github.mag0716.memorytraining.viewmodel;
 
+import android.content.Context;
+import android.content.res.TypedArray;
 import android.databinding.BaseObservable;
 import android.databinding.Bindable;
 import android.support.annotation.IdRes;
 import android.support.annotation.IntRange;
+import android.support.annotation.NonNull;
 
 import com.github.mag0716.memorytraining.BR;
 import com.github.mag0716.memorytraining.R;
@@ -25,6 +28,11 @@ public class TrainingViewModel extends BaseObservable {
     public static final int CATEGORY_ALL = -2;
 
     /**
+     * Navigation Drawer の高さ
+     * status bar + Toolbar
+     */
+    private int drawerHeaderHeight;
+    /**
      * 現在選択中のカテゴリ
      */
     private int currentCategory = CATEGORY_ONLY_NEED_TRAINING;
@@ -36,6 +44,23 @@ public class TrainingViewModel extends BaseObservable {
      * 訓練データを追加可能かどうか
      */
     private boolean addable = true;
+
+    @Bindable
+    public int getDrawerHeaderHeight() {
+        return drawerHeaderHeight;
+    }
+
+    private void setDrawerHeaderHeight(int drawerHeaderHeight) {
+        this.drawerHeaderHeight = drawerHeaderHeight;
+        notifyPropertyChanged(BR.drawerHeaderHeight);
+    }
+
+    public void calculateDrawerHeaderHeight(@NonNull Context context, int statusBarHeight) {
+        final TypedArray styledAttributes = context.getTheme().obtainStyledAttributes(new int[]{android.R.attr.actionBarSize});
+        final int toolbarHeight = (int) styledAttributes.getDimension(0, 0);
+        styledAttributes.recycle();
+        setDrawerHeaderHeight(statusBarHeight + toolbarHeight);
+    }
 
     @Bindable
     public int getCurrentCategory() {

--- a/app/src/main/java/com/github/mag0716/memorytraining/viewmodel/TrainingViewModel.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/viewmodel/TrainingViewModel.java
@@ -2,6 +2,7 @@ package com.github.mag0716.memorytraining.viewmodel;
 
 import android.databinding.BaseObservable;
 import android.databinding.Bindable;
+import android.support.annotation.IntRange;
 
 import com.github.mag0716.memorytraining.BR;
 
@@ -11,9 +12,30 @@ import com.github.mag0716.memorytraining.BR;
 public class TrainingViewModel extends BaseObservable {
 
     /**
+     * 訓練が必要なデータのみ
+     */
+    public static final int CATEGORY_ONLY_NEED_TRAINING = -1;
+    /**
+     * 全てのデータ
+     */
+    public static final int CATEGORY_ALL = -2;
+
+    /**
+     * 現在選択中のカテゴリ
+     */
+    private int currentCategory = CATEGORY_ONLY_NEED_TRAINING;
+    /**
      * 訓練データを追加可能かどうか
      */
     private boolean addable = true;
+
+    public int getCurrentCategory() {
+        return currentCategory;
+    }
+
+    public void setCurrentCategory(@IntRange(from = CATEGORY_ALL, to = CATEGORY_ONLY_NEED_TRAINING) int currentCategory) {
+        this.currentCategory = currentCategory;
+    }
 
     @Bindable
     public boolean isAddable() {

--- a/app/src/main/java/com/github/mag0716/memorytraining/viewmodel/TrainingViewModel.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/viewmodel/TrainingViewModel.java
@@ -2,9 +2,13 @@ package com.github.mag0716.memorytraining.viewmodel;
 
 import android.databinding.BaseObservable;
 import android.databinding.Bindable;
+import android.support.annotation.IdRes;
 import android.support.annotation.IntRange;
 
 import com.github.mag0716.memorytraining.BR;
+import com.github.mag0716.memorytraining.R;
+
+import timber.log.Timber;
 
 /**
  * Created by mag0716 on 2017/07/20.
@@ -33,12 +37,14 @@ public class TrainingViewModel extends BaseObservable {
      */
     private boolean addable = true;
 
+    @Bindable
     public int getCurrentCategory() {
         return currentCategory;
     }
 
-    public void setCurrentCategory(@IntRange(from = CATEGORY_ALL, to = CATEGORY_ONLY_NEED_TRAINING) int currentCategory) {
+    private void setCurrentCategory(@IntRange(from = CATEGORY_ALL, to = CATEGORY_ONLY_NEED_TRAINING) int currentCategory) {
         this.currentCategory = currentCategory;
+        notifyPropertyChanged(BR.currentCategory);
     }
 
     @Bindable
@@ -59,5 +65,16 @@ public class TrainingViewModel extends BaseObservable {
     public void setAddable(boolean addable) {
         this.addable = addable;
         notifyPropertyChanged(BR.addable);
+    }
+
+    public void changeCategory(@IdRes int categoryId) {
+        Timber.d("changeCategory : %d", categoryId);
+        if (categoryId == R.id.navigation_all_data) {
+            setCurrentCategory(CATEGORY_ALL);
+        } else if (categoryId == R.id.navigation_training_data) {
+            setCurrentCategory(CATEGORY_ONLY_NEED_TRAINING);
+        } else {
+            throw new IllegalArgumentException("invalid category ID");
+        }
     }
 }

--- a/app/src/main/java/com/github/mag0716/memorytraining/viewmodel/TrainingViewModel.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/viewmodel/TrainingViewModel.java
@@ -25,6 +25,10 @@ public class TrainingViewModel extends BaseObservable {
      */
     private int currentCategory = CATEGORY_ONLY_NEED_TRAINING;
     /**
+     * カテゴリを選択可能かどうか
+     */
+    private boolean selectableCategory = true;
+    /**
      * 訓練データを追加可能かどうか
      */
     private boolean addable = true;
@@ -35,6 +39,16 @@ public class TrainingViewModel extends BaseObservable {
 
     public void setCurrentCategory(@IntRange(from = CATEGORY_ALL, to = CATEGORY_ONLY_NEED_TRAINING) int currentCategory) {
         this.currentCategory = currentCategory;
+    }
+
+    @Bindable
+    public boolean isSelectableCategory() {
+        return selectableCategory;
+    }
+
+    public void setSelectableCategory(boolean selectableCategory) {
+        this.selectableCategory = selectableCategory;
+        notifyPropertyChanged(BR.selectableCategory);
     }
 
     @Bindable

--- a/app/src/main/res/layout/activity_training.xml
+++ b/app/src/main/res/layout/activity_training.xml
@@ -65,6 +65,7 @@
             android:layout_height="match_parent"
             android:layout_gravity="start"
             android:fitsSystemWindows="true"
+            app:itemBackground="@android:color/transparent"
             app:menu="@menu/menu_training_activity_drawer" />
     </android.support.v4.widget.DrawerLayout>
 </layout>

--- a/app/src/main/res/layout/activity_training.xml
+++ b/app/src/main/res/layout/activity_training.xml
@@ -14,41 +14,57 @@
             type="com.github.mag0716.memorytraining.presenter.TrainingPresenter" />
     </data>
 
-    <android.support.design.widget.CoordinatorLayout
+    <android.support.v4.widget.DrawerLayout
+        android:id="@+id/drawer_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context="com.github.mag0716.memorytraining.activity.TrainingActivity">
+        android:fitsSystemWindows="true"
+        tools:context="com.github.mag0716.memorytraining.activity.TrainingActivity"
+        tools:openDrawer="start">
 
-        <android.support.design.widget.AppBarLayout
+        <android.support.design.widget.CoordinatorLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:theme="@style/AppTheme.AppBarOverlay">
+            android:layout_height="match_parent">
 
-            <android.support.v7.widget.Toolbar
-                android:id="@+id/toolbar"
+            <android.support.design.widget.AppBarLayout
                 android:layout_width="match_parent"
-                android:layout_height="?attr/actionBarSize"
-                android:background="?attr/colorPrimary"
-                app:popupTheme="@style/AppTheme.PopupOverlay" />
+                android:layout_height="wrap_content"
+                android:theme="@style/AppTheme.AppBarOverlay">
 
-        </android.support.design.widget.AppBarLayout>
+                <android.support.v7.widget.Toolbar
+                    android:id="@+id/toolbar"
+                    android:layout_width="match_parent"
+                    android:layout_height="?attr/actionBarSize"
+                    android:background="?attr/colorPrimary"
+                    app:popupTheme="@style/AppTheme.PopupOverlay" />
 
-        <FrameLayout
-            android:id="@+id/content"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+            </android.support.design.widget.AppBarLayout>
 
-        <android.support.design.widget.FloatingActionButton
-            android:id="@+id/fab"
+            <FrameLayout
+                android:id="@+id/content"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+            <android.support.design.widget.FloatingActionButton
+                android:id="@+id/fab"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="bottom|end"
+                android:layout_margin="@dimen/fab_margin"
+                android:onClick="@{() -> presenter.addMemory()}"
+                app:layout_behavior="com.github.mag0716.memorytraining.view.behavior.FloatingActionButtonShowHideBehavior"
+                app:srcCompat="@drawable/ic_add_white_24dp"
+                app:visibleOrInvisible="@{viewModel.isAddable}" />
+
+        </android.support.design.widget.CoordinatorLayout>
+
+        <android.support.design.widget.NavigationView
+            android:id="@+id/navigation_view"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="bottom|end"
-            android:layout_margin="@dimen/fab_margin"
-            android:onClick="@{() -> presenter.addMemory()}"
-            app:layout_behavior="com.github.mag0716.memorytraining.view.behavior.FloatingActionButtonShowHideBehavior"
-            app:srcCompat="@drawable/ic_add_white_24dp"
-            app:visibleOrInvisible="@{viewModel.isAddable}" />
-
-    </android.support.design.widget.CoordinatorLayout>
+            android:layout_height="match_parent"
+            android:layout_gravity="start"
+            android:fitsSystemWindows="true"
+            app:menu="@menu/menu_training_activity_drawer" />
+    </android.support.v4.widget.DrawerLayout>
 </layout>

--- a/app/src/main/res/layout/drawer_header.xml
+++ b/app/src/main/res/layout/drawer_header.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <data>
+
+        <variable
+            name="viewModel"
+            type="com.github.mag0716.memorytraining.viewmodel.TrainingViewModel" />
+    </data>
+
+    <android.support.constraint.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="@{viewModel.drawerHeaderHeight, default = wrap_content}"
+        android:background="?attr/colorPrimary">
+
+    </android.support.constraint.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/drawer_header.xml
+++ b/app/src/main/res/layout/drawer_header.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<layout xmlns:android="http://schemas.android.com/apk/res/android">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
 
@@ -12,7 +13,21 @@
     <android.support.constraint.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="@{viewModel.drawerHeaderHeight, default = wrap_content}"
-        android:background="?attr/colorPrimary">
+        android:background="?attr/colorPrimary"
+        android:paddingBottom="@dimen/navigation_drawer_vertical_padding"
+        android:paddingEnd="@dimen/navigation_drawer_horizontal_padding"
+        android:paddingStart="@dimen/navigation_drawer_horizontal_padding"
+        android:paddingTop="@dimen/navigation_drawer_vertical_padding">
 
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="ver.1.0.0"
+            android:textAppearance="@style/AppTheme.Text.Drawer.Header"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="1" />
     </android.support.constraint.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/view_list_item.xml
+++ b/app/src/main/res/layout/view_list_item.xml
@@ -8,10 +8,6 @@
         <variable
             name="viewModel"
             type="com.github.mag0716.memorytraining.viewmodel.ListItemViewModel" />
-
-        <variable
-            name="presenter"
-            type="com.github.mag0716.memorytraining.presenter.ListPresenter" />
     </data>
 
     <android.support.v7.widget.CardView
@@ -20,9 +16,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/cards_horizontal_margin"
-        android:layout_marginStart="@dimen/cards_horizontal_margin"
-        android:foreground="?android:attr/selectableItemBackground"
-        android:onLongClick="@{() -> presenter.edit(viewModel.id)}">
+        android:layout_marginStart="@dimen/cards_horizontal_margin">
 
         <android.support.constraint.ConstraintLayout
             android:layout_width="match_parent"
@@ -34,22 +28,11 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:text="@{viewModel.question}"
-                app:layout_constraintEnd_toStartOf="@id/open_and_close_icon"
+                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/answer_text"
                 app:layout_constraintTop_toTopOf="parent"
                 tools:text="access" />
-
-            <ImageView
-                android:id="@+id/open_and_close_icon"
-                style="@style/AppTheme.Card.Action"
-                android:layout_width="@dimen/touch_target_minimum_size"
-                android:layout_height="@dimen/touch_target_minimum_size"
-                android:layout_marginEnd="@dimen/cards_action_button_row_padding"
-                android:onClick="@{() -> viewModel.toggleShowingAnswer()}"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:srcCompat="@{viewModel.openAndCloseIcon}" />
 
             <TextView
                 android:id="@+id/answer_text"
@@ -61,40 +44,6 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/question_text"
                 tools:text="アクセス、通行権" />
-
-            <Button
-                android:id="@+id/ok_button"
-                style="@style/AppTheme.Card.Action"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="@dimen/cards_action_button_row_padding"
-                android:layout_marginStart="@dimen/cards_action_button_row_padding"
-                android:onClick="@{() -> presenter.levelUp(viewModel.getId())}"
-                android:text="OK"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toStartOf="@+id/ng_button"
-                app:layout_constraintHorizontal_bias="1"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/answer_text" />
-
-            <Button
-                android:id="@+id/ng_button"
-                style="@style/AppTheme.Card.Action"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/cards_action_button_row_padding"
-                android:onClick="@{() -> presenter.levelDown(viewModel.getId())}"
-                android:text="NG"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/answer_text" />
-
-            <android.support.constraint.Group
-                android:id="@+id/answer_group"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:constraint_referenced_ids="answer_text"
-                app:visibleOrGone="@{viewModel.isShowingAnswer}" />
 
         </android.support.constraint.ConstraintLayout>
 

--- a/app/src/main/res/layout/view_trainable_list_item.xml
+++ b/app/src/main/res/layout/view_trainable_list_item.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="viewModel"
+            type="com.github.mag0716.memorytraining.viewmodel.ListItemViewModel" />
+
+        <variable
+            name="presenter"
+            type="com.github.mag0716.memorytraining.presenter.ListPresenter" />
+    </data>
+
+    <android.support.v7.widget.CardView
+        android:id="@+id/memory_card"
+        style="@style/AppTheme.Card"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/cards_horizontal_margin"
+        android:layout_marginStart="@dimen/cards_horizontal_margin"
+        android:foreground="?android:attr/selectableItemBackground"
+        android:onLongClick="@{() -> presenter.edit(viewModel.id)}">
+
+        <android.support.constraint.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:id="@+id/question_text"
+                style="@style/AppTheme.Card.Title"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:text="@{viewModel.question}"
+                app:layout_constraintEnd_toStartOf="@id/open_and_close_icon"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/answer_text"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="access" />
+
+            <ImageView
+                android:id="@+id/open_and_close_icon"
+                style="@style/AppTheme.Card.Action"
+                android:layout_width="@dimen/touch_target_minimum_size"
+                android:layout_height="@dimen/touch_target_minimum_size"
+                android:layout_marginEnd="@dimen/cards_action_button_row_padding"
+                android:onClick="@{() -> viewModel.toggleShowingAnswer()}"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:srcCompat="@{viewModel.openAndCloseIcon}" />
+
+            <TextView
+                android:id="@+id/answer_text"
+                style="@style/AppTheme.Card.SubText"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:text="@{viewModel.answer}"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/question_text"
+                tools:text="アクセス、通行権" />
+
+            <Button
+                android:id="@+id/ok_button"
+                style="@style/AppTheme.Card.Action"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="@dimen/cards_action_button_row_padding"
+                android:layout_marginStart="@dimen/cards_action_button_row_padding"
+                android:onClick="@{() -> presenter.levelUp(viewModel.getId())}"
+                android:text="OK"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@+id/ng_button"
+                app:layout_constraintHorizontal_bias="1"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/answer_text" />
+
+            <Button
+                android:id="@+id/ng_button"
+                style="@style/AppTheme.Card.Action"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/cards_action_button_row_padding"
+                android:onClick="@{() -> presenter.levelDown(viewModel.getId())}"
+                android:text="NG"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/answer_text" />
+
+            <android.support.constraint.Group
+                android:id="@+id/answer_group"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:constraint_referenced_ids="answer_text"
+                app:visibleOrGone="@{viewModel.isShowingAnswer}" />
+
+        </android.support.constraint.ConstraintLayout>
+
+    </android.support.v7.widget.CardView>
+</layout>

--- a/app/src/main/res/menu/menu_training_activity_drawer.xml
+++ b/app/src/main/res/menu/menu_training_activity_drawer.xml
@@ -6,6 +6,7 @@
     <group android:checkableBehavior="single">
         <item
             android:id="@+id/navigation_training_data"
+            android:checked="true"
             android:title="訓練対象" />
         <item
             android:id="@+id/navigation_all_data"

--- a/app/src/main/res/menu/menu_training_activity_drawer.xml
+++ b/app/src/main/res/menu/menu_training_activity_drawer.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:showIn="navigation_view">
+
+    <group android:checkableBehavior="single">
+        <item
+            android:id="@+id/navigation_training_data"
+            android:title="訓練対象" />
+        <item
+            android:id="@+id/navigation_all_data"
+            android:title="全て" />
+    </group>
+
+    <item android:title="その他">
+        <menu>
+            <item
+                android:id="@+id/navigation_settings"
+                android:icon="@drawable/ic_settings_white_24dp"
+                android:title="@string/action_settings" />
+        </menu>
+    </item>
+
+</menu>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,3 +1,8 @@
 <resources>
     <dimen name="fab_margin">16dp</dimen>
+    <!-- Default screen margins, per the Android Design guidelines. -->
+    <dimen name="activity_horizontal_margin">16dp</dimen>
+    <dimen name="activity_vertical_margin">16dp</dimen>
+    <dimen name="nav_header_vertical_spacing">8dp</dimen>
+    <dimen name="nav_header_height">176dp</dimen>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -3,6 +3,4 @@
     <!-- Default screen margins, per the Android Design guidelines. -->
     <dimen name="activity_horizontal_margin">16dp</dimen>
     <dimen name="activity_vertical_margin">16dp</dimen>
-    <dimen name="nav_header_vertical_spacing">8dp</dimen>
-    <dimen name="nav_header_height">176dp</dimen>
 </resources>

--- a/app/src/main/res/values/dimens_material.xml
+++ b/app/src/main/res/values/dimens_material.xml
@@ -6,6 +6,16 @@
     <dimen name="view_vertical_margin">8dp</dimen>
     <dimen name="touch_target_minimum_size">48dp</dimen>
 
+    <!-- Navigation drawer(https://material.io/guidelines/patterns/navigation-drawer.html#navigation-drawer-specs) -->
+    <dimen name="navigation_drawer_maximum_width">280dp</dimen>
+    <dimen name="navigation_drawer_elevation">16dp</dimen>
+    <dimen name="navigation_drawer_horizontal_padding">16dp</dimen>
+    <dimen name="navigation_drawer_vertical_padding">8dp</dimen>
+    <dimen name="navigation_drawer_sub_title_height">56dp</dimen>
+    <dimen name="navigation_drawer_view_vertical_margin">8dp</dimen>
+    <dimen name="navigation_drawer_list_item_height">48dp</dimen>
+    <dimen name="navigation_drawer_text_size">14sp</dimen>
+
     <!-- Buttons(https://material.io/guidelines/components/buttons.html) -->
     <dimen name="buttons_minimum_width">88dp</dimen>
     <dimen name="buttons_minimum_height">36dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,4 +14,6 @@
     <string name="edit_question_hint">質問を入力してください</string>
     <string name="edit_answer_hint">答えを入力してください</string>
     <string name="edit_save_button_name">保存</string>
+    <string name="navigation_drawer_open">Open navigation drawer</string>
+    <string name="navigation_drawer_close">Close navigation drawer</string>
 </resources>

--- a/app/src/main/res/values/text_styles.xml
+++ b/app/src/main/res/values/text_styles.xml
@@ -1,0 +1,7 @@
+<resources>
+
+    <!-- https://material.io/guidelines/style/typography.html#typography-styles -->
+    <style name="AppTheme.Text.Drawer.Header" parent="TextAppearance.AppCompat.Body1">
+        <item name="android:textColor">@color/primary_light_text</item>
+    </style>
+</resources>


### PR DESCRIPTION
## Description

編集や削除のために、一覧画面で Spinner などでカテゴリを変更して、登録してあるデータを全て表示できるようにする。

## TODO

- [x] カテゴリ変更のための UI 追加
- [x] レイアウト調整
- [x] カテゴリにあったデータを取得、表示する
- [x] 全てのデータ表示中は、表示のみにする
    - [x] OK, NG ボタン非表示
    - [x] 開閉ボタン非表示
    - [x] タップ不可

## Link

#11 

## Reference

* https://material.io/guidelines/patterns/navigation-drawer.html
* http://guides.codepath.com/android/fragment-navigation-drawer
* https://android.jlelse.eu/navigation-drawer-styling-according-material-design-5306190da08f