### PR TITLE
一覧画面のセルはタップ可能にすべきか？

### DIFF
--- a/app/src/main/java/com/github/mag0716/memorytraining/presenter/ListPresenter.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/presenter/ListPresenter.java
@@ -129,13 +129,10 @@ public class ListPresenter implements IPresenter {
      * データの編集
      *
      * @param id 編集対象データ ID
-     * @return 必ず true
-     * onLongClick でバインディングさせるために boolean を戻り値にしている
      */
-    public boolean edit(long id) {
+    public void edit(long id) {
         Timber.d("edit : %d", id);
         view.editMemory(id);
-        return true;
     }
 
     private Single<Memory> loadMemory(long id) {

--- a/app/src/main/java/com/github/mag0716/memorytraining/view/adapter/MemoryListAdapter.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/view/adapter/MemoryListAdapter.java
@@ -60,6 +60,7 @@ public class MemoryListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         final ListItemViewModel viewModel = viewModelList.get(position);
         if (viewHolder instanceof MemoryViewHolder) {
             ((MemoryViewHolder) viewHolder).binding.setViewModel(viewModel);
+            ((MemoryViewHolder) viewHolder).binding.setPresenter(presenter);
             ((MemoryViewHolder) viewHolder).binding.executePendingBindings();
         } else if (viewHolder instanceof TrainableMemoryViewHolder) {
             ((TrainableMemoryViewHolder) viewHolder).binding.setViewModel(viewModel);

--- a/app/src/main/res/layout/view_list_item.xml
+++ b/app/src/main/res/layout/view_list_item.xml
@@ -8,6 +8,10 @@
         <variable
             name="viewModel"
             type="com.github.mag0716.memorytraining.viewmodel.ListItemViewModel" />
+
+        <variable
+            name="presenter"
+            type="com.github.mag0716.memorytraining.presenter.ListPresenter" />
     </data>
 
     <android.support.v7.widget.CardView
@@ -16,7 +20,9 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/cards_horizontal_margin"
-        android:layout_marginStart="@dimen/cards_horizontal_margin">
+        android:layout_marginStart="@dimen/cards_horizontal_margin"
+        android:foreground="?android:attr/selectableItemBackground"
+        android:onClick="@{() -> presenter.edit(viewModel.id)}">
 
         <android.support.constraint.ConstraintLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/view_trainable_list_item.xml
+++ b/app/src/main/res/layout/view_trainable_list_item.xml
@@ -20,9 +20,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/cards_horizontal_margin"
-        android:layout_marginStart="@dimen/cards_horizontal_margin"
-        android:foreground="?android:attr/selectableItemBackground"
-        android:onLongClick="@{() -> presenter.edit(viewModel.id)}">
+        android:layout_marginStart="@dimen/cards_horizontal_margin">
 
         <android.support.constraint.ConstraintLayout
             android:layout_width="match_parent"


### PR DESCRIPTION
## Description

一覧画面のセルで回答を表示するためには、右上のボタンをタップする必要がある。
そのボタンのみで表示しているのは、誤った操作で回答を表示して欲しくないという理由からそうしている。

セル全体をタップ可能にした方が使いやすいかを再検討する。

## TODO

- [x] 「訓練可能」カテゴリでは操作ミスで回答表示を避けるためにタップ不可にする
- [x] 「全て」カテゴリはデータ編集目的なのでセルタップで編集画面へ遷移させる

## Link

* 単純に foreground をセットすると、CardView からはみ出るので対応が必要
    * https://stackoverflow.com/questions/24475150/android-l-cardview-visual-touch-feedback