### PR TITLE
FAB が表示できなくなる

### DIFF
--- a/app/src/main/java/com/github/mag0716/memorytraining/activity/TrainingActivity.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/activity/TrainingActivity.java
@@ -187,6 +187,7 @@ public class TrainingActivity extends AppCompatActivity
         final ListFragment fragment = (ListFragment) fragmentManager.findFragmentByTag(ListFragment.TAG);
         Timber.d("showTrainingList : %d, %s", category, fragment);
         fragmentManager.beginTransaction().replace(R.id.content, ListFragment.newInstance(category), ListFragment.TAG).commit();
+        binding.fab.show();
     }
 
     @Override


### PR DESCRIPTION
## Description

スクロール可能な状態で FAB を消して、スクロール不可能な画面に遷移すると FAB を表示できなくなる

## Link

## TODO

- [x] カテゴリ切り替えなどでは FAB を必ず表示する

## Check List

- [x] FAB 表示状態でカテゴリ変更
- [x] FAB 非表示状態でカテゴリ変更
- [x] カテゴリ変更後にスクロールで FAB の表示状態切り替え