### PR TITLE
BG -> FG で保存ができなくなる

### DIFF
--- a/app/src/main/java/com/github/mag0716/memorytraining/presenter/EditPresenter.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/presenter/EditPresenter.java
@@ -39,7 +39,7 @@ public class EditPresenter implements IPresenter {
 
     @Override
     public void detachView() {
-        disposables.dispose();
+        disposables.clear();
         this.view = null;
     }
 


### PR DESCRIPTION
## Description

追加画面へ遷移し、データを入力
BG -> FG にして、保存ボタンをタップ
ボタン自体はタップ可能だが、保存処理が実行されない

## Link

* http://gfx.hatenablog.com/entry/2015/06/08/091656
* https://stackoverflow.com/questions/39203791/how-to-use-compositedisposable-of-rxjava-2

## Cause

CompositeDisposable#dispose していたので、
FG 後に CompositeDisposable が再利用できななかったために発生。

dispose -> clear で再利用可能にした。

## Check List

- [x] 追加画面
- [x] 編集画面