### PR TITLE
Android Studio 3.0 beta5 にアップデート

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,15 +1,15 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
-def support_lib_version = "26.0.1"
+def support_lib_version = "26.0.2"
 def arch_lib_version = "1.0.0-alpha9"
-def play_services_version = "11.0.4"
+def play_services_version = "11.2.2"
 def leakcanary_version = "1.5"
 def permission_dispatcher_version = "2.3.2"
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "25.0.3"
+    buildToolsVersion "26.0.1"
     defaultConfig {
         applicationId "com.github.mag0716.memorytraining"
         minSdkVersion 19

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-beta1'
+        classpath 'com.android.tools.build:gradle:3.0.0-beta5'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Aug 01 22:28:07 JST 2017
+#Sat Sep 09 19:00:44 JST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-rc-1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
## Description

Android Studio 3.0 を beta5 にアップデート
support library も最新バージョンにアップデート

## Link

* https://androidstudio.googleblog.com/2017/09/android-studio-30-beta-5.html
* https://developer.android.com/topic/libraries/support-library/revisions.html

## TODO

- [x] バージョン更新

## Check List

- [x] テストが通ること