### PR TITLE
Firebase のトラッキングでテストに失敗していたのでテスト時はトラッキングを無効化

### DIFF
--- a/app/src/main/java/com/github/mag0716/memorytraining/Application.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/Application.java
@@ -41,7 +41,7 @@ public class Application extends android.app.Application implements IConfigurati
         LeakCanary.install(this);
         // TODO: ログ出力を抑制する
         Timber.plant(new Timber.DebugTree());
-        trackerConductor.addTracker(new FirebaseTracker(this));
+        setUpTracker();
     }
 
     @Override
@@ -72,5 +72,10 @@ public class Application extends android.app.Application implements IConfigurati
 
     public TrackerConductor getTrackerConductor() {
         return trackerConductor;
+    }
+
+    @RestrictTo(RestrictTo.Scope.SUBCLASSES)
+    protected void setUpTracker() {
+        trackerConductor.addTracker(new FirebaseTracker(this));
     }
 }

--- a/app/src/test/AndroidManifest.xml
+++ b/app/src/test/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.github.mag0716.memorytraining">
+
+    <application
+        android:name=".TestApplication"
+        tools:replace="android:name" />
+
+</manifest>

--- a/app/src/test/java/com/github/mag0716/memorytraining/TestApplication.java
+++ b/app/src/test/java/com/github/mag0716/memorytraining/TestApplication.java
@@ -1,0 +1,9 @@
+package com.github.mag0716.memorytraining;
+
+public class TestApplication extends Application {
+
+    @Override
+    protected void setUpTracker() {
+        // テスト実行時には不要なのでトラッキングは無効化する
+    }
+}

--- a/app/src/test/resources/robolectric.properties
+++ b/app/src/test/resources/robolectric.properties
@@ -1,4 +1,4 @@
 sdk=23
-manifest=src/main/AndroidManifest.xml
+manifest=src/test/AndroidManifest.xml
 constant=com.github.mag0716.memorytraining.BuildConfig
 assetDir=../../schemas


### PR DESCRIPTION
## Description

トラッキングを追加したことでテストに失敗する様になっていた

```
android.content.res.Resources$NotFoundException: String resource ID #0x7f0d003f

	at android.content.res.Resources.getText(Resources.java:312)
	at android.content.res.Resources.getString(Resources.java:400)
	at com.google.android.gms.common.internal.zzbz.getString(Unknown Source)
	at com.google.android.gms.common.api.internal.zzca.<init>(Unknown Source)
	at com.google.android.gms.common.api.internal.zzca.zzcc(Unknown Source)
	at com.google.android.gms.internal.zzcbp.zzuh(Unknown Source)
	at com.google.android.gms.internal.zzcds.initialize(Unknown Source)
	at com.google.android.gms.internal.zzccu.<init>(Unknown Source)
	at com.google.android.gms.internal.zzccu.zzdm(Unknown Source)
	at com.google.firebase.analytics.FirebaseAnalytics.getInstance(Unknown Source)
	at com.github.mag0716.memorytraining.tracking.FirebaseTracker.<init>(FirebaseTracker.java:59)
	at com.github.mag0716.memorytraining.Application.setUpTracker(Application.java:79)
	at com.github.mag0716.memorytraining.TestApplication.setUpTracker(TestApplication.java:8)
	at com.github.mag0716.memorytraining.Application.onCreate(Application.java:44)
	at org.robolectric.android.internal.ParallelUniverse.setUpApplicationState(ParallelUniverse.java:137)
	at org.robolectric.RobolectricTestRunner.beforeTest(RobolectricTestRunner.java:290)
	at org.robolectric.internal.SandboxTestRunner$2.evaluate(SandboxTestRunner.java:203)
	at org.robolectric.internal.SandboxTestRunner.runChild(SandboxTestRunner.java:109)
	at org.robolectric.internal.SandboxTestRunner.runChild(SandboxTestRunner.java:36)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.robolectric.internal.SandboxTestRunner$1.evaluate(SandboxTestRunner.java:63)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runners.Suite.runChild(Suite.java:128)
	at org.junit.runners.Suite.runChild(Suite.java:27)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:51)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
	at com.intellij.rt.execution.application.AppMainV2.main(AppMainV2.java:131)
```
## Link

* #47

## TODO

* テスト時はトラッキングを無効化

## Check List

- [x] テストに通ること