### PR TITLE
Android Studio 3.0 RC1 にアップデート

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,15 +1,15 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
-def support_lib_version = "26.0.2"
+def support_lib_version = "26.1.0"
 def arch_lib_version = "1.0.0-alpha9"
-def play_services_version = "11.2.2"
+def play_services_version = "11.4.2"
 def leakcanary_version = "1.5"
 def permission_dispatcher_version = "2.3.2"
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "26.0.1"
+    buildToolsVersion '26.0.2'
     defaultConfig {
         applicationId "com.github.mag0716.memorytraining"
         minSdkVersion 19

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-beta5'
+        classpath 'com.android.tools.build:gradle:3.0.0-rc1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
## Description

Android Studio を最新の 3.0 RC1 にアップデート

## Link

* https://androidstudio.googleblog.com/2017/10/android-studio-30-rc-1-now-available.html
* https://developer.android.com/topic/libraries/support-library/revisions.html#26-1-0
* https://developers.google.com/android/guides/releases#october_3_2017_-_version_1142

## TODO

- [x] Android Studio 3.0 にアップデート
- [x] support library アップデート
- [x] Google Play Services アップデート

## Check List

- [x] テストが成功すること