### PR TITLE
必ず AlarmManager が利用されてしまう

### DIFF
--- a/app/src/main/java/com/github/mag0716/memorytraining/service/TaskConductor.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/service/TaskConductor.java
@@ -80,6 +80,7 @@ public class TaskConductor {
             ITaskRegister taskRegister = taskRegisterType.getTaskRegister();
             if (taskRegister != null && taskRegister.isAvailable(context)) {
                 this.taskRegister = taskRegister;
+                break;
             }
         }
     }


### PR DESCRIPTION
## Description

定期実行には有効なクラスを利用する様にしたが、必ず AlarmManager が利用される様になっている。

## Link

* #62

## TODO

- [x] TaskConductor#updateTaskRegister 修正

## Check List

- [x] GcmNetworkManager が利用されること
- [x] 定期実行が可能であること