### PR TITLE
NotificationCompat.Builder コンストラクタの正しい実装方法

### DIFF
--- a/app/src/main/java/com/github/mag0716/memorytraining/Application.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/Application.java
@@ -7,6 +7,7 @@ import android.support.annotation.RestrictTo;
 
 import com.github.mag0716.memorytraining.event.EventBus;
 import com.github.mag0716.memorytraining.event.StartTrainingEvent;
+import com.github.mag0716.memorytraining.notification.NotificationConductor;
 import com.github.mag0716.memorytraining.repository.database.ApplicationDatabase;
 import com.github.mag0716.memorytraining.service.TaskConductor;
 import com.github.mag0716.memorytraining.tracking.FirebaseTracker;
@@ -47,6 +48,7 @@ public class Application extends android.app.Application implements IConfigurati
         Timber.plant(new Timber.DebugTree());
         startTrainingEventBus = new EventBus<>();
         setUpTracker();
+        NotificationConductor.initChannel(this);
     }
 
     @Override

--- a/app/src/main/java/com/github/mag0716/memorytraining/notification/NotificationConductor.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/notification/NotificationConductor.java
@@ -1,9 +1,12 @@
 package com.github.mag0716.memorytraining.notification;
 
 import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.NotificationManagerCompat;
@@ -32,6 +35,8 @@ import timber.log.Timber;
  */
 public class NotificationConductor {
 
+    private static final String NOTIFICATION_CHANNEL_ID = "TrainingNotificationChannel";
+
     /**
      * Notification 種別
      */
@@ -53,6 +58,28 @@ public class NotificationConductor {
     }
 
     private NotificationConductor() {
+    }
+
+    /**
+     * NotificationChannel を初期化
+     *
+     * @param context Context
+     */
+    public static void initChannel(@NonNull Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            final NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+            if (notificationManager != null) {
+                if (notificationManager.getNotificationChannel(NOTIFICATION_CHANNEL_ID) == null) {
+                    final NotificationChannel channel = new NotificationChannel(NOTIFICATION_CHANNEL_ID,
+                            context.getString(R.string.notification_channel_name),
+                            NotificationManager.IMPORTANCE_DEFAULT);
+                    channel.setDescription(context.getString(R.string.notification_channel_description));
+                    channel.enableVibration(true);
+                    channel.setShowBadge(true);
+                    notificationManager.createNotificationChannel(channel);
+                }
+            }
+        }
     }
 
     /**
@@ -85,7 +112,7 @@ public class NotificationConductor {
                         notificationId,
                         intent,
                         PendingIntent.FLAG_UPDATE_CURRENT);
-                Notification notification = new NotificationCompat.Builder(context)
+                Notification notification = new NotificationCompat.Builder(context, NOTIFICATION_CHANNEL_ID)
                         .setSmallIcon(R.drawable.ic_alarm_black_24dp)
                         .setContentTitle(context.getString(R.string.notification_training_title))
                         .setContentText(context.getString(R.string.notification_training_message))

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,8 @@
     <!-- notification -->
     <string name="notification_training_title">訓練日時になりました</string>
     <string name="notification_training_message">訓練対象データがあります。復習しましょう。</string>
+    <string name="notification_channel_name">訓練通知</string>
+    <string name="notification_channel_description">訓練日時を通知で知らせます</string>
 
     <!-- 一覧画面 -->
     <string name="list_empty_message">データがありません。\n追加画面より追加して訓練を始めましょう。</string>


### PR DESCRIPTION
## Description

support library 26.0.0 から `NotificationCompat.Builder(Context)` は deprecated になった。
第2引数に channel ID を指定する必要があるのだが、自分でチャンネルを作らずデフォルトのままでいい場合はどう実装するのが正しいのかを調査する。

## Link

* https://stackoverflow.com/questions/44443690/notificationcompat-with-api-26

## TODO

- [x] 定期実行用の通知を受け取るためのチャンネルを追加

## Check List

- [x] Android 8 端末で Notification が表示されること