### PR TITLE
Android Architecture Component を 1.0.0 にアップデート

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 def support_lib_version = "26.1.0"
-def arch_lib_version = "1.0.0-rc1"
+def arch_lib_version = "1.0.0"
 def play_services_version = "11.4.2"
 def leakcanary_version = "1.5"
 def permission_dispatcher_version = "2.3.2"


### PR DESCRIPTION
## Description

Android Architecture Components 1.0.0 がリリースされたので、アップデートする。
変更点は LiveData のみなのでバージョンだけ更新する。

## Link

* https://developer.android.com/topic/libraries/architecture/release-notes.html#100_-_november_6_2017

## TODO

- [x] バージョン更新

## Check List

- [x] テストが通ること