### PR TITLE
設定画面より定期実行に利用する API を選択可能にする

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     implementation "com.android.support:design:${support_lib_version}"
     implementation "com.android.support:recyclerview-v7:${support_lib_version}"
     implementation "com.android.support:cardview-v7:${support_lib_version}"
+    implementation "com.android.support:preference-v14:${support_lib_version}"
     implementation 'com.android.support.constraint:constraint-layout:1.1.0-beta1'
     implementation "android.arch.persistence.room:runtime:${arch_lib_version}"
     annotationProcessor "android.arch.persistence.room:compiler:${arch_lib_version}"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -89,6 +89,7 @@ dependencies {
     // for test
     testImplementation 'junit:junit:4.12'
     testImplementation "org.robolectric:robolectric:3.3.2"
+    testImplementation "org.robolectric:shadows-play-services:3.3.2"
     testImplementation 'org.hamcrest:hamcrest-library:1.3'
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,6 +26,8 @@
             </intent-filter>
         </activity>
 
+        <activity android:name=".activity.SettingActivity" />
+
         <activity
             android:name="com.google.android.gms.oss.licenses.OssLicensesActivity"
             android:theme="@style/AppTheme.License" />
@@ -51,10 +53,10 @@
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </receiver>
-
         <receiver
             android:name=".receiver.AlarmManagerReceiver"
             android:exported="false" />
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/github/mag0716/memorytraining/Application.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/Application.java
@@ -2,6 +2,8 @@ package com.github.mag0716.memorytraining;
 
 import android.annotation.SuppressLint;
 import android.arch.persistence.room.Room;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.annotation.RestrictTo;
 
@@ -10,6 +12,7 @@ import com.github.mag0716.memorytraining.event.StartTrainingEvent;
 import com.github.mag0716.memorytraining.notification.NotificationConductor;
 import com.github.mag0716.memorytraining.repository.database.ApplicationDatabase;
 import com.github.mag0716.memorytraining.service.TaskConductor;
+import com.github.mag0716.memorytraining.service.TaskRegisterType;
 import com.github.mag0716.memorytraining.tracking.FirebaseTracker;
 import com.github.mag0716.memorytraining.tracking.TrackerConductor;
 import com.squareup.leakcanary.LeakCanary;
@@ -72,7 +75,10 @@ public class Application extends android.app.Application implements IConfigurati
     @Override
     public TaskConductor getTaskConductor() {
         if (taskConductor == null) {
-            taskConductor = new TaskConductor(this, getDatabase().memoryDao());
+            final SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(this);
+            taskConductor = new TaskConductor(this,
+                    getDatabase().memoryDao(),
+                    TaskRegisterType.getTaskRegister(this, preferences.getString(getString(R.string.setting_api_key), null)));
         }
         return taskConductor;
     }

--- a/app/src/main/java/com/github/mag0716/memorytraining/activity/SettingActivity.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/activity/SettingActivity.java
@@ -2,16 +2,23 @@ package com.github.mag0716.memorytraining.activity;
 
 import android.content.Context;
 import android.content.Intent;
+import android.databinding.DataBindingUtil;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentTransaction;
 import android.support.v7.app.AppCompatActivity;
 
 import com.github.mag0716.memorytraining.R;
+import com.github.mag0716.memorytraining.databinding.ActivitySettingBinding;
+import com.github.mag0716.memorytraining.fragment.SettingApiFragment;
 
 /**
  * 設定画面
  */
 public class SettingActivity extends AppCompatActivity {
+
+    private ActivitySettingBinding binding;
 
     /**
      * 起動用の Intent を生成
@@ -26,6 +33,13 @@ public class SettingActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_setting);
+        binding = DataBindingUtil.setContentView(this, R.layout.activity_setting);
+
+        if (savedInstanceState == null) {
+            final FragmentManager fragmentManager = getSupportFragmentManager();
+            final FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
+            fragmentTransaction.replace(R.id.container, SettingApiFragment.newInstance(), SettingApiFragment.TAG);
+            fragmentTransaction.commit();
+        }
     }
 }

--- a/app/src/main/java/com/github/mag0716/memorytraining/activity/SettingActivity.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/activity/SettingActivity.java
@@ -1,0 +1,31 @@
+package com.github.mag0716.memorytraining.activity;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v7.app.AppCompatActivity;
+
+import com.github.mag0716.memorytraining.R;
+
+/**
+ * 設定画面
+ */
+public class SettingActivity extends AppCompatActivity {
+
+    /**
+     * 起動用の Intent を生成
+     *
+     * @param context Context
+     * @return 起動用 Intent
+     */
+    public static Intent createIntent(@NonNull Context context) {
+        return new Intent(context, SettingActivity.class);
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_setting);
+    }
+}

--- a/app/src/main/java/com/github/mag0716/memorytraining/activity/TrainingActivity.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/activity/TrainingActivity.java
@@ -145,12 +145,14 @@ public class TrainingActivity extends AppCompatActivity
 
     @Override
     public boolean onNavigationItemSelected(@NonNull MenuItem menuItem) {
-        final int groupId = menuItem.getGroupId();
+        final int menuGroupId = menuItem.getGroupId();
         final int menuId = menuItem.getItemId();
-        if (groupId == R.id.training_category) {
+        if (menuGroupId == R.id.training_category) {
             viewModel.changeCategory(menuId);
         } else {
-            if (menuId == R.id.navigation_license) {
+            if (menuId == R.id.navigation_settings) {
+                startActivity(SettingActivity.createIntent(this));
+            } else if (menuId == R.id.navigation_license) {
                 startActivity(new Intent(this, OssLicensesMenuActivity.class));
             }
         }
@@ -199,6 +201,7 @@ public class TrainingActivity extends AppCompatActivity
     /**
      * 表示状態を更新する
      */
+
     private void updateView() {
         final Fragment currentFragment = fragmentManager.findFragmentById(R.id.content);
         Timber.d("updateView : %s", currentFragment);

--- a/app/src/main/java/com/github/mag0716/memorytraining/fragment/SettingApiFragment.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/fragment/SettingApiFragment.java
@@ -1,5 +1,6 @@
 package com.github.mag0716.memorytraining.fragment;
 
+import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.support.v7.preference.ListPreference;
@@ -7,6 +8,7 @@ import android.support.v7.preference.PreferenceFragmentCompat;
 
 import com.github.mag0716.memorytraining.Application;
 import com.github.mag0716.memorytraining.R;
+import com.github.mag0716.memorytraining.service.ITaskRegister;
 import com.github.mag0716.memorytraining.service.TaskRegisterType;
 
 import java.util.List;
@@ -40,13 +42,16 @@ public class SettingApiFragment extends PreferenceFragmentCompat implements Shar
 
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
+        final Context context = getContext();
         setPreferencesFromResource(R.xml.setting_api_preferences, rootKey);
         final ListPreference listPreference = (ListPreference) findPreference(getString(R.string.setting_api_key));
         listPreference.setTitle(getString(R.string.setting_api_title));
         listPreference.setSummary(getString(R.string.setting_api_summary));
-        final List<String> taskRegisterList = TaskRegisterType.getRegisterNameList(getContext());
+        final List<String> taskRegisterList = TaskRegisterType.getRegisterNameList(context);
         listPreference.setEntries(taskRegisterList.toArray(new CharSequence[taskRegisterList.size()]));
         listPreference.setEntryValues(taskRegisterList.toArray(new CharSequence[taskRegisterList.size()]));
+        final ITaskRegister currentTaskRegister = ((Application) getActivity().getApplication()).getTaskConductor().getTaskRegister();
+        listPreference.setValue(currentTaskRegister.getName(context));
     }
 
     @Override

--- a/app/src/main/java/com/github/mag0716/memorytraining/fragment/SettingApiFragment.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/fragment/SettingApiFragment.java
@@ -1,0 +1,37 @@
+package com.github.mag0716.memorytraining.fragment;
+
+import android.os.Bundle;
+import android.support.v7.preference.PreferenceFragmentCompat;
+
+import com.github.mag0716.memorytraining.R;
+
+/**
+ * 定期実行 API 設定画面
+ * <p>
+ * Created by mag0716 on 2017/10/30.
+ */
+public class SettingApiFragment extends PreferenceFragmentCompat {
+
+    public static final String TAG = SettingApiFragment.class.getCanonicalName();
+
+    /**
+     * SettingApiFragment 生成
+     *
+     * @return SettingApiFragment
+     */
+    public static SettingApiFragment newInstance() {
+        return new SettingApiFragment();
+    }
+
+    /**
+     * コンストラクタ
+     */
+    public SettingApiFragment() {
+
+    }
+
+    @Override
+    public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
+        setPreferencesFromResource(R.xml.setting_api_preferences, rootKey);
+    }
+}

--- a/app/src/main/java/com/github/mag0716/memorytraining/fragment/SettingApiFragment.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/fragment/SettingApiFragment.java
@@ -1,16 +1,24 @@
 package com.github.mag0716.memorytraining.fragment;
 
+import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.support.v7.preference.ListPreference;
 import android.support.v7.preference.PreferenceFragmentCompat;
 
+import com.github.mag0716.memorytraining.Application;
 import com.github.mag0716.memorytraining.R;
+import com.github.mag0716.memorytraining.service.TaskRegisterType;
+
+import java.util.List;
+
+import timber.log.Timber;
 
 /**
  * 定期実行 API 設定画面
  * <p>
  * Created by mag0716 on 2017/10/30.
  */
-public class SettingApiFragment extends PreferenceFragmentCompat {
+public class SettingApiFragment extends PreferenceFragmentCompat implements SharedPreferences.OnSharedPreferenceChangeListener {
 
     public static final String TAG = SettingApiFragment.class.getCanonicalName();
 
@@ -33,5 +41,31 @@ public class SettingApiFragment extends PreferenceFragmentCompat {
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
         setPreferencesFromResource(R.xml.setting_api_preferences, rootKey);
+        final ListPreference listPreference = (ListPreference) findPreference(getString(R.string.setting_api_key));
+        listPreference.setTitle(getString(R.string.setting_api_title));
+        listPreference.setSummary(getString(R.string.setting_api_summary));
+        final List<String> taskRegisterList = TaskRegisterType.getRegisterNameList(getContext());
+        listPreference.setEntries(taskRegisterList.toArray(new CharSequence[taskRegisterList.size()]));
+        listPreference.setEntryValues(taskRegisterList.toArray(new CharSequence[taskRegisterList.size()]));
+    }
+
+    @Override
+    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+        final String taskRegisterName = sharedPreferences.getString(key, null);
+        Timber.d("onSharedPreferenceChanged : %s", taskRegisterName);
+        ((Application) getActivity().getApplication()).getTaskConductor().updateTaskRegister(TaskRegisterType.getTaskRegister(getContext(), taskRegisterName));
+        // TODO: エラーで利用できない項目を選択したら復旧させてみる
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        getPreferenceManager().getSharedPreferences().registerOnSharedPreferenceChangeListener(this);
+    }
+
+    @Override
+    public void onStop() {
+        super.onStop();
+        getPreferenceManager().getSharedPreferences().unregisterOnSharedPreferenceChangeListener(this);
     }
 }

--- a/app/src/main/java/com/github/mag0716/memorytraining/service/ITaskRegister.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/service/ITaskRegister.java
@@ -13,16 +13,24 @@ public interface ITaskRegister {
     /**
      * 利用可能かどうか
      *
-     * @param context
-     * @return
+     * @param context Context
+     * @return API が利用可能かどうか
      */
     boolean isAvailable(@NonNull Context context);
 
     /**
+     * 復旧可能かどうか
+     *
+     * @param context Context
+     * @return API が利用不可の場合にユーザが操作することで利用可能になるかどうか
+     */
+    boolean isResolvable(@NonNull Context context);
+
+    /**
      * タスクの登録
      *
-     * @param context
-     * @param memory
+     * @param context Context
+     * @param memory  登録対象
      */
     void registerTask(@NonNull Context context, @NonNull Memory memory);
 }

--- a/app/src/main/java/com/github/mag0716/memorytraining/service/ITaskRegister.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/service/ITaskRegister.java
@@ -11,6 +11,24 @@ import com.github.mag0716.memorytraining.model.Memory;
 public interface ITaskRegister {
 
     /**
+     * 利用する API の名前を返却
+     *
+     * @param context Context
+     * @return 利用する API 名
+     */
+    @NonNull
+    String getName(@NonNull Context context);
+
+    /**
+     * 利用する API の説明を返却
+     *
+     * @param context Context
+     * @return 利用する API の説明
+     */
+    @NonNull
+    String getDescription(@NonNull Context context);
+
+    /**
      * 利用可能かどうか
      *
      * @param context Context

--- a/app/src/main/java/com/github/mag0716/memorytraining/service/ITaskRegister.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/service/ITaskRegister.java
@@ -51,4 +51,11 @@ public interface ITaskRegister {
      * @param memory  登録対象
      */
     void registerTask(@NonNull Context context, @NonNull Memory memory);
+
+    /**
+     * 登録済みのタスクを解除する
+     *
+     * @param context Context
+     */
+    void unregisterTask(@NonNull Context context);
 }

--- a/app/src/main/java/com/github/mag0716/memorytraining/service/TaskConductor.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/service/TaskConductor.java
@@ -38,6 +38,16 @@ public class TaskConductor {
     }
 
     /**
+     * 利用中の定期実行タスク登録 API を返却する
+     *
+     * @return 利用中の API
+     */
+    @NonNull
+    public ITaskRegister getTaskRegister() {
+        return taskRegister;
+    }
+
+    /**
      * 直近の訓練日時のデータがあればタスクを登録する
      */
     public void registerTaskIfNeeded() {

--- a/app/src/main/java/com/github/mag0716/memorytraining/service/TaskRegisterType.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/service/TaskRegisterType.java
@@ -32,9 +32,16 @@ public enum TaskRegisterType {
         return taskRegister;
     }
 
+    /**
+     * 選択可能な登録 API 一覧を返却
+     *
+     * @param context Context
+     * @return 選択可能な登録 API 一覧
+     */
     public static List<String> getRegisterNameList(@NonNull Context context) {
         return Stream.of(TaskRegisterType.values())
-                .filter(type -> type.getTaskRegister() != null)
+                // TODO: SettingApiFragment 側で復旧処理を実装したら利用不可でも復旧可能だったら選択可能にする
+                .filter(type -> type.getTaskRegister() != null && type.getTaskRegister().isAvailable(context))
                 .map(taskRegisterType -> taskRegisterType.getTaskRegister().getName(context))
                 .toList();
     }

--- a/app/src/main/java/com/github/mag0716/memorytraining/service/TaskRegisterType.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/service/TaskRegisterType.java
@@ -2,6 +2,8 @@ package com.github.mag0716.memorytraining.service;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.text.TextUtils;
 
 import com.annimon.stream.Stream;
 import com.github.mag0716.memorytraining.service.alarmmanager.AlarmManagerRegister;
@@ -46,4 +48,20 @@ public enum TaskRegisterType {
                 .toList();
     }
 
+    /**
+     * 名前に合致する登録 API を返却
+     *
+     * @param context          Context
+     * @param taskRegisterName 登録 API 名
+     * @return 登録 API
+     */
+    @Nullable
+    public static ITaskRegister getTaskRegister(@NonNull Context context, @Nullable String taskRegisterName) {
+        return Stream.of(TaskRegisterType.values())
+                .filter(type -> type.getTaskRegister() != null)
+                .map(TaskRegisterType::getTaskRegister)
+                .filter(taskRegister -> TextUtils.equals(taskRegisterName, taskRegister.getName(context)))
+                .findSingle()
+                .orElse(null);
+    }
 }

--- a/app/src/main/java/com/github/mag0716/memorytraining/service/TaskRegisterType.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/service/TaskRegisterType.java
@@ -1,7 +1,13 @@
 package com.github.mag0716.memorytraining.service;
 
+import android.content.Context;
+import android.support.annotation.NonNull;
+
+import com.annimon.stream.Stream;
 import com.github.mag0716.memorytraining.service.alarmmanager.AlarmManagerRegister;
 import com.github.mag0716.memorytraining.service.gcmnetworkmanager.GcmNetworkManagerRegister;
+
+import java.util.List;
 
 /**
  * タスク登録種別
@@ -25,4 +31,12 @@ public enum TaskRegisterType {
     public ITaskRegister getTaskRegister() {
         return taskRegister;
     }
+
+    public static List<String> getRegisterNameList(@NonNull Context context) {
+        return Stream.of(TaskRegisterType.values())
+                .filter(type -> type.getTaskRegister() != null)
+                .map(taskRegisterType -> taskRegisterType.getTaskRegister().getName(context))
+                .toList();
+    }
+
 }

--- a/app/src/main/java/com/github/mag0716/memorytraining/service/alarmmanager/AlarmManagerRegister.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/service/alarmmanager/AlarmManagerRegister.java
@@ -52,4 +52,15 @@ public class AlarmManagerRegister implements ITaskRegister {
                     AlarmManagerReceiver.createPendingIntent(context, intent));
         }
     }
+
+    @Override
+    public void unregisterTask(@NonNull Context context) {
+        final AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+        if (alarmManager != null) {
+            alarmManager.cancel(
+                    AlarmManagerReceiver.createPendingIntent(
+                            context,
+                            new Intent(context, AlarmManagerReceiver.class)));
+        }
+    }
 }

--- a/app/src/main/java/com/github/mag0716/memorytraining/service/alarmmanager/AlarmManagerRegister.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/service/alarmmanager/AlarmManagerRegister.java
@@ -22,6 +22,12 @@ public class AlarmManagerRegister implements ITaskRegister {
     }
 
     @Override
+    public boolean isResolvable(@NonNull Context context) {
+        // AlarmManager は常に利用可能
+        return false;
+    }
+
+    @Override
     public void registerTask(@NonNull Context context, @NonNull Memory memory) {
         final Intent intent = new Intent(context, AlarmManagerReceiver.class);
         intent.putExtra(TaskConductor.TASK_EXTRAS_TRAINING_DATETIME_KEY, memory.getNextTrainingDatetime());

--- a/app/src/main/java/com/github/mag0716/memorytraining/service/alarmmanager/AlarmManagerRegister.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/service/alarmmanager/AlarmManagerRegister.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.support.annotation.NonNull;
 import android.support.v4.app.AlarmManagerCompat;
 
+import com.github.mag0716.memorytraining.R;
 import com.github.mag0716.memorytraining.model.Memory;
 import com.github.mag0716.memorytraining.receiver.AlarmManagerReceiver;
 import com.github.mag0716.memorytraining.service.ITaskRegister;
@@ -15,6 +16,18 @@ import com.github.mag0716.memorytraining.service.TaskConductor;
  * Created by mag0716 on 2017/09/20.
  */
 public class AlarmManagerRegister implements ITaskRegister {
+    @NonNull
+    @Override
+    public String getName(@NonNull Context context) {
+        return context.getString(R.string.setting_api_alarmmanager_name);
+    }
+
+    @NonNull
+    @Override
+    public String getDescription(@NonNull Context context) {
+        return context.getString(R.string.setting_api_alarmmanager_description);
+    }
+
     @Override
     public boolean isAvailable(@NonNull Context context) {
         // AlarmManager は常に利用可能

--- a/app/src/main/java/com/github/mag0716/memorytraining/service/gcmnetworkmanager/GcmNetworkManagerRegister.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/service/gcmnetworkmanager/GcmNetworkManagerRegister.java
@@ -32,6 +32,12 @@ public class GcmNetworkManagerRegister implements ITaskRegister {
     }
 
     @Override
+    public boolean isResolvable(@NonNull Context context) {
+        GoogleApiAvailability availability = GoogleApiAvailability.getInstance();
+        return availability.isUserResolvableError(availability.isGooglePlayServicesAvailable(context));
+    }
+
+    @Override
     public void registerTask(@NonNull Context context, @NonNull Memory memory) {
         final long delayMilliseconds = memory.getNextTrainingDatetime() - System.currentTimeMillis();
         final Bundle extras = new Bundle();

--- a/app/src/main/java/com/github/mag0716/memorytraining/service/gcmnetworkmanager/GcmNetworkManagerRegister.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/service/gcmnetworkmanager/GcmNetworkManagerRegister.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 
+import com.github.mag0716.memorytraining.R;
 import com.github.mag0716.memorytraining.model.Memory;
 import com.github.mag0716.memorytraining.service.ITaskRegister;
 import com.github.mag0716.memorytraining.service.TaskConductor;
@@ -24,6 +25,18 @@ import java.util.concurrent.TimeUnit;
 public class GcmNetworkManagerRegister implements ITaskRegister {
 
     private static final String TASK_TAG = "MemoryTask";
+
+    @NonNull
+    @Override
+    public String getName(@NonNull Context context) {
+        return context.getString(R.string.setting_api_gcmnetworkmanager_name);
+    }
+
+    @NonNull
+    @Override
+    public String getDescription(@NonNull Context context) {
+        return context.getString(R.string.setting_api_gcmnetworkmanager_description);
+    }
 
     @Override
     public boolean isAvailable(@NonNull Context context) {

--- a/app/src/main/java/com/github/mag0716/memorytraining/service/gcmnetworkmanager/GcmNetworkManagerRegister.java
+++ b/app/src/main/java/com/github/mag0716/memorytraining/service/gcmnetworkmanager/GcmNetworkManagerRegister.java
@@ -69,4 +69,10 @@ public class GcmNetworkManagerRegister implements ITaskRegister {
                 .build();
         manager.schedule(task);
     }
+
+    @Override
+    public void unregisterTask(@NonNull Context context) {
+        final GcmNetworkManager manager = GcmNetworkManager.getInstance(context);
+        manager.cancelAllTasks(GcmNetworkManagerService.class);
+    }
 }

--- a/app/src/main/res/layout/activity_setting.xml
+++ b/app/src/main/res/layout/activity_setting.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="com.github.mag0716.memorytraining.activity.SettingActivity">
+
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/activity_setting.xml
+++ b/app/src/main/res/layout/activity_setting.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context="com.github.mag0716.memorytraining.activity.SettingActivity">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
-</android.support.constraint.ConstraintLayout>
+    <android.support.constraint.ConstraintLayout
+        android:id="@+id/container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context="com.github.mag0716.memorytraining.activity.SettingActivity">
+
+    </android.support.constraint.ConstraintLayout>
+</layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,4 +23,11 @@
     <string name="edit_save_button_name">保存</string>
     <string name="navigation_drawer_open">Open navigation drawer</string>
     <string name="navigation_drawer_close">Close navigation drawer</string>
+
+    <!-- 設定画面 -->
+    <string name="setting_api_key">SettingApi</string>
+    <string name="setting_api_alarmmanager_name">AlarmManager</string>
+    <string name="setting_api_alarmmanager_description">全ての端末で利用できます</string>
+    <string name="setting_api_gcmnetworkmanager_name">GcmNetworkManager</string>
+    <string name="setting_api_gcmnetworkmanager_description">Play Services 開発者サービスが必要です</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,6 +26,8 @@
 
     <!-- 設定画面 -->
     <string name="setting_api_key">SettingApi</string>
+    <string name="setting_api_title">定期実行 API</string>
+    <string name="setting_api_summary">定期実行に利用する API を設定します</string>
     <string name="setting_api_alarmmanager_name">AlarmManager</string>
     <string name="setting_api_alarmmanager_description">全ての端末で利用できます</string>
     <string name="setting_api_gcmnetworkmanager_name">GcmNetworkManager</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -8,6 +8,7 @@
         <item name="colorAccent">@color/primary_dark</item>
         <item name="colorControlHighlight">@color/primary_light</item>
         <item name="android:windowBackground">@color/background</item>
+        <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
     </style>
 
     <style name="AppTheme.NoActionBar">

--- a/app/src/main/res/xml/setting_api_preferences.xml
+++ b/app/src/main/res/xml/setting_api_preferences.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+    <PreferenceCategory
+        android:key="setting_api_category"
+        android:title="定期実行タスク API">
+
+        <Preference
+            android:key="setting_api_alarm_manager"
+            android:summary="全ての端末で利用できます。"
+            android:title="AlarmManager" />
+
+        <Preference
+            android:key="setting_api_gcm_network_manager"
+            android:summary="Play Services 開発者サービスが必要です"
+            android:title="GcmNetworkManager" />
+    </PreferenceCategory>
+</PreferenceScreen>

--- a/app/src/main/res/xml/setting_api_preferences.xml
+++ b/app/src/main/res/xml/setting_api_preferences.xml
@@ -3,15 +3,6 @@
     <PreferenceCategory
         android:key="setting_api_category"
         android:title="定期実行タスク API">
-
-        <Preference
-            android:key="setting_api_alarm_manager"
-            android:summary="全ての端末で利用できます。"
-            android:title="AlarmManager" />
-
-        <Preference
-            android:key="setting_api_gcm_network_manager"
-            android:summary="Play Services 開発者サービスが必要です"
-            android:title="GcmNetworkManager" />
+        <ListPreference android:key="@string/setting_api_key" />
     </PreferenceCategory>
 </PreferenceScreen>

--- a/app/src/test/kotlin/com/github/mag0716/memorytraining/presenter/ListPresenterTest.kt
+++ b/app/src/test/kotlin/com/github/mag0716/memorytraining/presenter/ListPresenterTest.kt
@@ -105,6 +105,10 @@ class ListPresenterTest {
             registeredMemory = memory
         }
 
+        override fun unregisterTask(context: Context) {
+            registeredMemory = null
+        }
+
         override fun getName(context: Context): String {
             return "name"
         }

--- a/app/src/test/kotlin/com/github/mag0716/memorytraining/presenter/ListPresenterTest.kt
+++ b/app/src/test/kotlin/com/github/mag0716/memorytraining/presenter/ListPresenterTest.kt
@@ -105,10 +105,21 @@ class ListPresenterTest {
             registeredMemory = memory
         }
 
+        override fun getName(context: Context): String {
+            return "name"
+        }
+
+        override fun getDescription(context: Context): String {
+            return "description"
+        }
+
         override fun isAvailable(context: Context): Boolean {
             return true
         }
 
+        override fun isResolvable(context: Context): Boolean {
+            return true;
+        }
     }
 
     lateinit var presenter: ListPresenter

--- a/app/src/test/kotlin/com/github/mag0716/memorytraining/service/TaskRegisterTypeTest.kt
+++ b/app/src/test/kotlin/com/github/mag0716/memorytraining/service/TaskRegisterTypeTest.kt
@@ -1,10 +1,13 @@
 package com.github.mag0716.memorytraining.service
 
 import com.github.mag0716.memorytraining.R
+import com.github.mag0716.memorytraining.service.alarmmanager.AlarmManagerRegister
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
 import org.hamcrest.Matchers.`is`
+import org.hamcrest.Matchers.nullValue
 import org.junit.Assert.assertThat
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -49,6 +52,28 @@ class TaskRegisterTypeTest {
         val list = TaskRegisterType.getRegisterNameList(RuntimeEnvironment.application)
         assertThat(list.size, `is`(1))
         assertThat(list[0], `is`(RuntimeEnvironment.application.getString(R.string.setting_api_alarmmanager_name)))
+    }
+
+    // endregion
+
+    // region getTaskRegister
+
+    @Test
+    fun getTaskRegister_指定した名前のITaskRegisterが返却されること() {
+        val taskRegister = TaskRegisterType.getTaskRegister(RuntimeEnvironment.application, RuntimeEnvironment.application.getString(R.string.setting_api_alarmmanager_name))
+        assertTrue(taskRegister is AlarmManagerRegister)
+    }
+
+    @Test
+    fun getTaskRegister_該当しない名前を渡した場合はnullが返却されること() {
+        val taskRegister = TaskRegisterType.getTaskRegister(RuntimeEnvironment.application, "invalid")
+        assertThat(taskRegister, `is`(nullValue()))
+    }
+
+    @Test
+    fun getTaskRegister_nullを渡した場合はnullが返却されること() {
+        val taskRegister = TaskRegisterType.getTaskRegister(RuntimeEnvironment.application, null)
+        assertThat(taskRegister, `is`(nullValue()))
     }
 
     // endregion

--- a/app/src/test/kotlin/com/github/mag0716/memorytraining/service/TaskRegisterTypeTest.kt
+++ b/app/src/test/kotlin/com/github/mag0716/memorytraining/service/TaskRegisterTypeTest.kt
@@ -1,13 +1,19 @@
 package com.github.mag0716.memorytraining.service
 
 import com.github.mag0716.memorytraining.R
+import com.google.android.gms.common.ConnectionResult
+import com.google.android.gms.common.GoogleApiAvailability
 import org.hamcrest.Matchers.`is`
 import org.junit.Assert.assertThat
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
+import org.robolectric.shadow.api.Shadow
+import org.robolectric.shadows.gms.common.ShadowGoogleApiAvailability
+
 
 /**
  * Created by mag0716 on 2017/11/08.
@@ -16,14 +22,33 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 class TaskRegisterTypeTest {
 
+    @Before
+    fun setUp() {
+    }
+
     // region getRegisterNameList
 
     @Test
-    fun getRegisterNameList_TaskRegister登録済みの名前の一覧が返却されること() {
+    fun getRegisterNameList_GooglePlayServicesが利用可能であれば全てのTaskRegisterの一覧が返却されること() {
+        val shadowGoogleApiAvailability: ShadowGoogleApiAvailability = Shadow.extract(GoogleApiAvailability.getInstance())
+        val expectedCode = ConnectionResult.SUCCESS
+        shadowGoogleApiAvailability.setIsGooglePlayServicesAvailable(expectedCode)
+
         val list = TaskRegisterType.getRegisterNameList(RuntimeEnvironment.application)
         assertThat(list.size, `is`(2))
         assertThat(list[0], `is`(RuntimeEnvironment.application.getString(R.string.setting_api_gcmnetworkmanager_name)))
         assertThat(list[1], `is`(RuntimeEnvironment.application.getString(R.string.setting_api_alarmmanager_name)))
+    }
+
+    @Test
+    fun getRegisterNameList_GooglePlayServicesが利用不可能であればGooglePlayServicesが不要のTaskRegisterの一覧が返却されること() {
+        val shadowGoogleApiAvailability: ShadowGoogleApiAvailability = Shadow.extract(GoogleApiAvailability.getInstance())
+        val expectedCode = ConnectionResult.SERVICE_DISABLED
+        shadowGoogleApiAvailability.setIsGooglePlayServicesAvailable(expectedCode)
+
+        val list = TaskRegisterType.getRegisterNameList(RuntimeEnvironment.application)
+        assertThat(list.size, `is`(1))
+        assertThat(list[0], `is`(RuntimeEnvironment.application.getString(R.string.setting_api_alarmmanager_name)))
     }
 
     // endregion

--- a/app/src/test/kotlin/com/github/mag0716/memorytraining/service/TaskRegisterTypeTest.kt
+++ b/app/src/test/kotlin/com/github/mag0716/memorytraining/service/TaskRegisterTypeTest.kt
@@ -1,0 +1,30 @@
+package com.github.mag0716.memorytraining.service
+
+import com.github.mag0716.memorytraining.R
+import org.hamcrest.Matchers.`is`
+import org.junit.Assert.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+/**
+ * Created by mag0716 on 2017/11/08.
+ */
+@Config(manifest = "src/main/AndroidManifest.xml")
+@RunWith(RobolectricTestRunner::class)
+class TaskRegisterTypeTest {
+
+    // region getRegisterNameList
+
+    @Test
+    fun getRegisterNameList_TaskRegister登録済みの名前の一覧が返却されること() {
+        val list = TaskRegisterType.getRegisterNameList(RuntimeEnvironment.application)
+        assertThat(list.size, `is`(2))
+        assertThat(list[0], `is`(RuntimeEnvironment.application.getString(R.string.setting_api_gcmnetworkmanager_name)))
+        assertThat(list[1], `is`(RuntimeEnvironment.application.getString(R.string.setting_api_alarmmanager_name)))
+    }
+
+    // endregion
+}


### PR DESCRIPTION
## Description

設定画面より定期実行に利用する API を選択可能にする
OS バージョンや Google Play Services のバージョンによって利用不可の API は選択不可にする必要がある

初期リリースでは、GcmNetworkManager と AlarmManager を切り替えられるようにする

## Link

#20 
* https://material.io/guidelines/patterns/settings.html

## TODO

- [x] 設定画面追加
- [x] 設定画面への動線追加
- [x] 利用可能 or 復帰可能な API を一覧に表示
    - * 復帰可能な API については後回し
- [x] 選択した API を保存、復帰
~~- [ ] 利用不可な API がバージョンアップなどによって復帰できるのであればその動線をユーザに提供する~~

## Check List

- [x] GcmNetworkManager -> AlarmManager
- [x] AlarmManager -> GcmNetworkManager
